### PR TITLE
fix "recipents" typo in blank.properties

### DIFF
--- a/conf/blank.properties
+++ b/conf/blank.properties
@@ -86,7 +86,7 @@ cf.adopter.name=
 #
 cf.email.mode=NONE
 # CSV of emails, required if cf.email.mode != NONE
-cf.email.recipents=
+cf.email.recipients=
 
 ## Required if cf.mode = REST
 # oeq.url=


### PR DESCRIPTION
This caught me the first time I tried to run the toolbox :)