### PR TITLE
Feature/20 change caching

### DIFF
--- a/src/main/java/org/apereo/openequella/tools/toolbox/CheckFilesDriver.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/CheckFilesDriver.java
@@ -150,21 +150,26 @@ public class CheckFilesDriver {
     return true;
   }
 
-    public static boolean run() {
-        switch(Config.getCheckFilesTypeConfig()) {
-            case REST: {
-                LOGGER.error("REST mode has not been reimplemented.  Exiting.");
-                //return (new AttachmentPingHandler()).execute();
-                return false;
-            } case DB_BATCH_ITEMS_PER_ITEM_ATTS:
-            case DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE:
-            case DB_ALL_ITEMS_ALL_ATTS: {
-                return (new CheckFilesDbHandler()).execute();
-            } default: {
-                LOGGER.error("Unknown CheckFiles mode of [{}]...", Config.get(Config.CF_MODE));
-                return false;
-            }
+  public static boolean run() {
+    switch (Config.getCheckFilesTypeConfig()) {
+      case REST:
+        {
+          LOGGER.error("REST mode has not been reimplemented.  Exiting.");
+          // return (new AttachmentPingHandler()).execute();
+          return false;
         }
+      case DB_BATCH_ITEMS_PER_ITEM_ATTS:
+      case DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE:
+      case DB_ALL_ITEMS_ALL_ATTS:
+        {
+          return (new CheckFilesDbHandler()).execute();
+        }
+      default:
+        {
+          LOGGER.error("Unknown CheckFiles mode of [{}]...", Config.get(Config.CF_MODE));
+          return false;
+        }
+    }
   }
 
   public static boolean finalizeRun() {

--- a/src/main/java/org/apereo/openequella/tools/toolbox/CheckFilesDriver.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/CheckFilesDriver.java
@@ -150,25 +150,21 @@ public class CheckFilesDriver {
     return true;
   }
 
-  public static boolean run() {
-    switch (Config.getCheckFilesTypeConfig()) {
-      case REST:
-        {
-          LOGGER.error("REST mode has not been reimplemented.  Exiting.");
-          // return (new AttachmentPingHandler()).execute();
-          return false;
+    public static boolean run() {
+        switch(Config.getCheckFilesTypeConfig()) {
+            case REST: {
+                LOGGER.error("REST mode has not been reimplemented.  Exiting.");
+                //return (new AttachmentPingHandler()).execute();
+                return false;
+            } case DB_BATCH_ITEMS_PER_ITEM_ATTS:
+            case DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE:
+            case DB_ALL_ITEMS_ALL_ATTS: {
+                return (new CheckFilesDbHandler()).execute();
+            } default: {
+                LOGGER.error("Unknown CheckFiles mode of [{}]...", Config.get(Config.CF_MODE));
+                return false;
+            }
         }
-      case DB_BATCH_ITEMS_PER_ITEM_ATTS:
-      case DB_ALL_ITEMS_ALL_ATTS:
-        {
-          return (new CheckFilesDbHandler()).execute();
-        }
-      default:
-        {
-          LOGGER.error("Unknown CheckFiles mode of [{}]...", Config.get(Config.CF_MODE));
-          return false;
-        }
-    }
   }
 
   public static boolean finalizeRun() {

--- a/src/main/java/org/apereo/openequella/tools/toolbox/Config.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/Config.java
@@ -144,7 +144,12 @@ public class Config {
   public enum CheckFilesType {
     REST, // Implemented, but needs testing after the open source effort
     DB_ALL_ITEMS_ALL_ATTS, // Currently the only supported method
-    DB_BATCH_ITEMS_PER_ITEM_ATTS // Implemented, but needs testing after the open source effort
+    DB_BATCH_ITEMS_PER_ITEM_ATTS,
+		// supports caching by a block of items, and for each item cached,
+		// pulls the attachments for the items and checks existance BEFORE
+		// getting more items.
+		DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE
+
   }
 
   public enum CheckFilesSupportedDB {
@@ -334,55 +339,46 @@ public class Config {
       checkConfigsEmail();
       checkConfig(CF_EMAIL_RECIPIENTS, true, true);
     }
-    if (validConfig) {
-      switch (CheckFilesType.valueOf(getConfig(CF_MODE))) {
-        case REST:
-          {
-            LOGGER.warn("WARNING:  This mode needs more testing...");
+    if(validConfig) {
+      switch(CheckFilesType.valueOf(getConfig(CF_MODE))) {
+      case REST: {
+        LOGGER.warn("WARNING:  This mode needs more testing...");
 
-            checkConfig(OEQ_URL, true, true);
-            checkConfig(OEQ_OAUTH_CLIENT_ID, true, true);
-            checkConfig(OEQ_OAUTH_CLIENT_SECRET, false, true);
-            checkConfig(CF_INSTITUTION_SHORTNAME, true, true);
-            checkConfig(CF_MAX_TRIES, true, true);
-            if (validConfig) checkInt(CF_MAX_TRIES, true);
-            checkConfig(CF_TESTING_TIMEOUT, true, true);
-            if (validConfig) checkInt(CF_TESTING_TIMEOUT, true);
-            break;
-          }
-        case DB_BATCH_ITEMS_PER_ITEM_ATTS:
-          {
-          }
-        case DB_ALL_ITEMS_ALL_ATTS:
-          {
-            checkConfig(CF_DB_URL, true, true);
-            checkConfig(CF_DB_USERNAME, true, true);
-            checkConfig(CF_DB_PASSWORD, false, true);
-            checkConfig(CF_DB_TYPE, true, true);
-            if (validConfig) checkEnum(CF_DB_TYPE, CheckFilesSupportedDB.class, true);
-            checkConfig(CF_FILESTORE_DIR, true, true);
-            checkConfig(CF_NUM_OF_ITEMS_PER_QUERY, true, true);
-            checkConfig(CF_FILTER_BY_COLLECTION, true, false);
-            checkConfig(CF_FILTER_BY_INSTITUTION, true, false);
-            checkConfig(CF_FILENAME_ENCODING_LIST, true, false);
-            if (validConfig && hasConfig(CF_FILENAME_ENCODING_LIST)) {
-              for (String key : getConfigAsStringArray(CF_FILENAME_ENCODING_LIST)) {
-                checkConfig(
-                    CF_FILENAME_ENCODING_BASE + key + CF_FILENAME_ENCODING_ORIGINAL, true, true);
-                checkConfig(
-                    CF_FILENAME_ENCODING_BASE + key + CF_FILENAME_ENCODING_RESULT, true, true);
-              }
-            }
-            break;
-          }
-        default:
-          {
-            LOGGER.warn(
-                "Property {} must be a known value  Instead was [{}].",
-                CF_MODE,
-                getConfig(CF_MODE));
-            validConfig = false;
-          }
+        checkConfig(OEQ_URL, true, true);
+        checkConfig(OEQ_OAUTH_CLIENT_ID, true, true);
+        checkConfig(OEQ_OAUTH_CLIENT_SECRET, false, true);
+        checkConfig(CF_INSTITUTION_SHORTNAME, true, true);
+        checkConfig(CF_MAX_TRIES, true, true);
+        if(validConfig) checkInt(CF_MAX_TRIES, true);
+        checkConfig(CF_TESTING_TIMEOUT, true, true);
+        if(validConfig) checkInt(CF_TESTING_TIMEOUT, true);
+        break;
+      } case DB_BATCH_ITEMS_PER_ITEM_ATTS: {
+					// pass through
+				} case DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE: {
+					// pass through
+	    } case DB_ALL_ITEMS_ALL_ATTS: {
+        checkConfig(CF_DB_URL, true, true);
+        checkConfig(CF_DB_USERNAME, true, true);
+        checkConfig(CF_DB_PASSWORD, false, true);
+        checkConfig(CF_DB_TYPE, true, true);
+        if(validConfig) checkEnum(CF_DB_TYPE, CheckFilesSupportedDB.class, true);
+        checkConfig(CF_FILESTORE_DIR, true, true);
+        checkConfig(CF_NUM_OF_ITEMS_PER_QUERY, true, true);
+        checkConfig(CF_FILTER_BY_COLLECTION, true, false);
+				checkConfig(CF_FILTER_BY_INSTITUTION, true, false);
+				checkConfig(CF_FILENAME_ENCODING_LIST, true, false);
+				if(validConfig && hasConfig(CF_FILENAME_ENCODING_LIST)) {
+					for(String key : getConfigAsStringArray(CF_FILENAME_ENCODING_LIST)) {
+						checkConfig(CF_FILENAME_ENCODING_BASE+key+CF_FILENAME_ENCODING_ORIGINAL, true, true);
+						checkConfig(CF_FILENAME_ENCODING_BASE+key+CF_FILENAME_ENCODING_RESULT, true, true);
+					}
+				}
+				break;
+      } default: {
+        LOGGER.warn("Property {} must be a known value  Instead was [{}].", CF_MODE, getConfig(CF_MODE));
+        validConfig = false;
+      }
       }
     }
   }

--- a/src/main/java/org/apereo/openequella/tools/toolbox/Config.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/Config.java
@@ -145,11 +145,10 @@ public class Config {
     REST, // Implemented, but needs testing after the open source effort
     DB_ALL_ITEMS_ALL_ATTS, // Currently the only supported method
     DB_BATCH_ITEMS_PER_ITEM_ATTS,
-		// supports caching by a block of items, and for each item cached,
-		// pulls the attachments for the items and checks existance BEFORE
-		// getting more items.
-		DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE
-
+    // supports caching by a block of items, and for each item cached,
+    // pulls the attachments for the items and checks existance BEFORE
+    // getting more items.
+    DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE
   }
 
   public enum CheckFilesSupportedDB {
@@ -339,46 +338,60 @@ public class Config {
       checkConfigsEmail();
       checkConfig(CF_EMAIL_RECIPIENTS, true, true);
     }
-    if(validConfig) {
-      switch(CheckFilesType.valueOf(getConfig(CF_MODE))) {
-      case REST: {
-        LOGGER.warn("WARNING:  This mode needs more testing...");
+    if (validConfig) {
+      switch (CheckFilesType.valueOf(getConfig(CF_MODE))) {
+        case REST:
+          {
+            LOGGER.warn("WARNING:  This mode needs more testing...");
 
-        checkConfig(OEQ_URL, true, true);
-        checkConfig(OEQ_OAUTH_CLIENT_ID, true, true);
-        checkConfig(OEQ_OAUTH_CLIENT_SECRET, false, true);
-        checkConfig(CF_INSTITUTION_SHORTNAME, true, true);
-        checkConfig(CF_MAX_TRIES, true, true);
-        if(validConfig) checkInt(CF_MAX_TRIES, true);
-        checkConfig(CF_TESTING_TIMEOUT, true, true);
-        if(validConfig) checkInt(CF_TESTING_TIMEOUT, true);
-        break;
-      } case DB_BATCH_ITEMS_PER_ITEM_ATTS: {
-					// pass through
-				} case DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE: {
-					// pass through
-	    } case DB_ALL_ITEMS_ALL_ATTS: {
-        checkConfig(CF_DB_URL, true, true);
-        checkConfig(CF_DB_USERNAME, true, true);
-        checkConfig(CF_DB_PASSWORD, false, true);
-        checkConfig(CF_DB_TYPE, true, true);
-        if(validConfig) checkEnum(CF_DB_TYPE, CheckFilesSupportedDB.class, true);
-        checkConfig(CF_FILESTORE_DIR, true, true);
-        checkConfig(CF_NUM_OF_ITEMS_PER_QUERY, true, true);
-        checkConfig(CF_FILTER_BY_COLLECTION, true, false);
-				checkConfig(CF_FILTER_BY_INSTITUTION, true, false);
-				checkConfig(CF_FILENAME_ENCODING_LIST, true, false);
-				if(validConfig && hasConfig(CF_FILENAME_ENCODING_LIST)) {
-					for(String key : getConfigAsStringArray(CF_FILENAME_ENCODING_LIST)) {
-						checkConfig(CF_FILENAME_ENCODING_BASE+key+CF_FILENAME_ENCODING_ORIGINAL, true, true);
-						checkConfig(CF_FILENAME_ENCODING_BASE+key+CF_FILENAME_ENCODING_RESULT, true, true);
-					}
-				}
-				break;
-      } default: {
-        LOGGER.warn("Property {} must be a known value  Instead was [{}].", CF_MODE, getConfig(CF_MODE));
-        validConfig = false;
-      }
+            checkConfig(OEQ_URL, true, true);
+            checkConfig(OEQ_OAUTH_CLIENT_ID, true, true);
+            checkConfig(OEQ_OAUTH_CLIENT_SECRET, false, true);
+            checkConfig(CF_INSTITUTION_SHORTNAME, true, true);
+            checkConfig(CF_MAX_TRIES, true, true);
+            if (validConfig) checkInt(CF_MAX_TRIES, true);
+            checkConfig(CF_TESTING_TIMEOUT, true, true);
+            if (validConfig) checkInt(CF_TESTING_TIMEOUT, true);
+            break;
+          }
+        case DB_BATCH_ITEMS_PER_ITEM_ATTS:
+          {
+            // pass through
+          }
+        case DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE:
+          {
+            // pass through
+          }
+        case DB_ALL_ITEMS_ALL_ATTS:
+          {
+            checkConfig(CF_DB_URL, true, true);
+            checkConfig(CF_DB_USERNAME, true, true);
+            checkConfig(CF_DB_PASSWORD, false, true);
+            checkConfig(CF_DB_TYPE, true, true);
+            if (validConfig) checkEnum(CF_DB_TYPE, CheckFilesSupportedDB.class, true);
+            checkConfig(CF_FILESTORE_DIR, true, true);
+            checkConfig(CF_NUM_OF_ITEMS_PER_QUERY, true, true);
+            checkConfig(CF_FILTER_BY_COLLECTION, true, false);
+            checkConfig(CF_FILTER_BY_INSTITUTION, true, false);
+            checkConfig(CF_FILENAME_ENCODING_LIST, true, false);
+            if (validConfig && hasConfig(CF_FILENAME_ENCODING_LIST)) {
+              for (String key : getConfigAsStringArray(CF_FILENAME_ENCODING_LIST)) {
+                checkConfig(
+                    CF_FILENAME_ENCODING_BASE + key + CF_FILENAME_ENCODING_ORIGINAL, true, true);
+                checkConfig(
+                    CF_FILENAME_ENCODING_BASE + key + CF_FILENAME_ENCODING_RESULT, true, true);
+              }
+            }
+            break;
+          }
+        default:
+          {
+            LOGGER.warn(
+                "Property {} must be a known value  Instead was [{}].",
+                CF_MODE,
+                getConfig(CF_MODE));
+            validConfig = false;
+          }
       }
     }
   }

--- a/src/main/java/org/apereo/openequella/tools/toolbox/checkFiles/CheckFilesDbHandler.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/checkFiles/CheckFilesDbHandler.java
@@ -35,6 +35,8 @@ import org.apache.logging.log4j.Logger;
 import org.apereo.openequella.tools.toolbox.Config;
 import org.apereo.openequella.tools.toolbox.utils.Check;
 import org.apereo.openequella.tools.toolbox.utils.CheckFilesUtils;
+import org.apereo.openequella.tools.toolbox.utils.FileUtils;
+import org.apereo.openequella.tools.toolbox.utils.Pair;
 import org.apereo.openequella.tools.toolbox.utils.WhereClauseExpression;
 
 /**
@@ -43,737 +45,764 @@ import org.apereo.openequella.tools.toolbox.utils.WhereClauseExpression;
  * the uuid / version 's filestore.
  */
 public class CheckFilesDbHandler {
-  private static final Logger logger = LogManager.getLogger(CheckFilesDbHandler.class);
+	private static final Logger logger = LogManager
+			.getLogger(CheckFilesDbHandler.class);
 
-  private Connection con;
-  private Map<Integer, CollectionRow> collectionsById = new HashMap<Integer, CollectionRow>();
-  private Map<String, InstitutionRow> institutionsByShortname =
-      new HashMap<String, InstitutionRow>();
-  private Map<Integer, InstitutionRow> institutionsById = new HashMap<Integer, InstitutionRow>();
-  // item id is the key. First ResultsRow in the cache list is the item
-  // details.
-  private Map<Integer, List<ResultsRow>> attachmentsCache =
-      new HashMap<Integer, List<ResultsRow>>();
+	private Connection con;
+	private Map<Integer, CollectionRow> collectionsById = new HashMap<Integer, CollectionRow>();
+	private Map<String, InstitutionRow> institutionsByShortname = new HashMap<String, InstitutionRow>();
+	private Map<Integer, InstitutionRow> institutionsById = new HashMap<Integer, InstitutionRow>();
+	// item id is the key. First ResultsRow in the cache list is the item
+	// details.
+	private Map<Integer, List<ResultsRow>> attachmentsCache = new HashMap<Integer, List<ResultsRow>>();
 
-  private List<WhereClauseExpression> whereClauseExpressions =
-      new ArrayList<WhereClauseExpression>();
+	private List<WhereClauseExpression> whereClauseExpressions = new ArrayList<WhereClauseExpression>();
 
-  public boolean execute() {
-    // Setup database connection
-    setupDbConnection(
-        Config.get(Config.CF_DB_URL),
-        Config.get(Config.CF_DB_USERNAME),
-        Config.get(Config.CF_DB_PASSWORD));
-    if (ReportManager.getInstance().hasFatalErrors()) {
-      closeConnection();
-      return false;
-    }
+	public boolean execute() {
+		// Setup database connection
+		setupDbConnection(Config.get(Config.CF_DB_URL),
+				Config.get(Config.CF_DB_USERNAME), Config
+						.get(Config.CF_DB_PASSWORD));
+		if(ReportManager.getInstance().hasFatalErrors()) {
+			closeConnection();
+			return false;
+		}
 
-    cacheCollections();
-    if (ReportManager.getInstance().hasFatalErrors()) {
-      closeConnection();
-      return false;
-    }
+		cacheCollections();
+		if(ReportManager.getInstance().hasFatalErrors()) {
+			closeConnection();
+			return false;
+		}
 
-    cacheInstitutions();
-    if (ReportManager.getInstance().hasFatalErrors()) {
-      closeConnection();
-      return false;
-    }
+		cacheInstitutions();
+		if(ReportManager.getInstance().hasFatalErrors()) {
+			closeConnection();
+			return false;
+		}
 
-    confirmFilterByCollection();
-    if (ReportManager.getInstance().hasFatalErrors()) {
-      closeConnection();
-      return false;
-    }
+		confirmFilterByCollection();
+		if(ReportManager.getInstance().hasFatalErrors()) {
+			closeConnection();
+			return false;
+		}
 
-    confirmFilterByInstitution();
-    if (ReportManager.getInstance().hasFatalErrors()) {
-      closeConnection();
-      return false;
-    }
+		confirmFilterByInstitution();
+		if (ReportManager.getInstance().hasFatalErrors()) {
+			closeConnection();
+			return false;
+		}
 
-    confirmAllInstitutionFilestores();
-    if (ReportManager.getInstance().hasFatalErrors()) {
-      closeConnection();
-      return false;
-    }
+		confirmAllInstitutionFilestores();
+		if (ReportManager.getInstance().hasFatalErrors()) {
+			closeConnection();
+			return false;
+		}
 
-    if (!ReportManager.getInstance().setupReportDetails()) {
-      closeConnection();
-      return false;
-    }
+		if (!ReportManager.getInstance().setupReportDetails()) {
+			closeConnection();
+			return false;
+		}
 
-    // Cache Items
-    if (Config.get(Config.CF_MODE).contains("ALL_ITEMS")) {
-      if (!cacheItemsAll()) {
-        closeConnection();
-        return false;
-      }
-    } else {
-      if (!cacheItemsBatched()) {
-        closeConnection();
-        return false;
-      }
-    }
+		if(Config.CheckFilesType.valueOf(Config.get(Config.CF_MODE)) == Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE) {
+			if (!cacheItemsBatched(true)) {
+				closeConnection();
+				return false;
+			}
+		} else {
+			// Cache Items
+			if (Config.get(Config.CF_MODE).contains("ALL_ITEMS")) {
+				if (!cacheItemsAll()) {
+					closeConnection();
+					return false;
+				}
+			} else {
+				if (!cacheItemsBatched(false)) {
+					closeConnection();
+					return false;
+				}
+			}
 
-    // Cache Attachments
-    if (Config.get(Config.CF_MODE).endsWith("ALL_ATTACHMENTS")) {
-      if (!cacheAttachmentsAll()) {
-        closeConnection();
-        return false;
-      }
-    } else {
-      if (!cacheAttachmentsPerItem()) {
-        closeConnection();
-        return false;
-      }
-    }
+			// Cache Attachments
+			if (Config.get(Config.CF_MODE).endsWith("ALL_ATTACHMENTS")) {
+				if (!cacheAttachmentsAll()) {
+					closeConnection();
+					return false;
+				}
+			} else {
+				if (!cacheAttachmentsPerItem()) {
+					closeConnection();
+					return false;
+				}
+			}
 
-    // Check attachments one item at a time
-    int counter = 0;
-    for (Integer itemId : attachmentsCache.keySet()) {
-      counter++;
-      if (!processItem(itemId, counter)) {
-        closeConnection();
-        return false;
-      }
-    }
+			// Check attachments one item at a time
+			int counter = 0;
+			for (Integer itemId : attachmentsCache.keySet()) {
+				counter++;
+				if (!processItem(itemId, counter)) {
+					closeConnection();
+					return false;
+				}
+			}
+		}
 
-    closeConnection();
-    return true;
-  }
+		closeConnection();
+		return true;
+	}
 
-  private boolean closeConnection() {
-    try {
-      if (con != null) {
-        con.close();
-        logger.debug("Closed DB connection");
-      }
-      return true;
-    } catch (SQLException e) {
-      logger.error("Unable to close connection due to {}", e.getMessage(), e);
-      return false;
-    }
-  }
+	private boolean closeConnection() {
+		try {
+			if (con != null) {
+				con.close();
+				logger.debug("Closed DB connection");
+			}
+			return true;
+		} catch (SQLException e) {
+			logger.error("Unable to close connection due to {}",
+					e.getMessage(), e);
+			return false;
+		}
+	}
 
-  /**
-   * @param itemId assumes this exists in the cache.
-   * @param itemCounter item counter
-   * @return
-   */
-  private boolean processItem(int itemId, int itemCounter) {
-    try {
-      logger.info("Processing item [{}]...", itemCounter);
-      ReportManager.getInstance().getStats().incNumTotalItems();
+	/**
+	 * 
+	 * @param itemId
+	 *            assumes this exists in the cache.
+	 * @param itemCounter
+	 *            item counter
+	 * @return
+	 */
+	private boolean processItem(int itemId, int itemCounter) {
+		try {
+			logger.info("Processing item [{}]...", itemCounter);
+			ReportManager.getInstance().getStats().incNumTotalItems();
 
-      List<ResultsRow> attachments = attachmentsCache.get(itemId);
-      // Remember, the attachmentsCache for an item is always seeded with
-      // an 'item' results row.
-      // If there is only the seeded ResultsRow, there were no attachments
-      // found.
-      if (attachments.size() == 1) {
-        attachments.get(0).setAttStatus(ResultsRow.NOATT);
-        ReportManager.getInstance().stdOutWriteln(attachments.get(0).toString());
-      } else {
-        boolean allGood = true;
-        final int rawTotal = attachments.size();
-        final int attTotal = rawTotal - 1; // See reason below.
-        // Start attCounter at 1 since the first element is always the
-        // item framework.
-        for (int attCounter = 1; attCounter < rawTotal; attCounter++) {
-          ResultsRow attRow = attachments.get(attCounter);
-          ReportManager.getInstance().getStats().incNumTotalAttachments();
-          logger.info(
-              "Processing item attachment [item#{}]-[att#{}] (out of [{}] attachments for this item)...",
-              itemCounter,
-              attCounter,
-              attTotal);
+			List<ResultsRow> attachments = attachmentsCache.get(itemId);
+			// Remember, the attachmentsCache for an item is always seeded with
+			// an 'item' results row.
+			// If there is only the seeded ResultsRow, there were no attachments
+			// found.
+			if (attachments.size() == 1) {
+				attachments.get(0).setAttStatus(ResultsRow.NOATT);
+				ReportManager.getInstance().stdOutWriteln(
+						attachments.get(0).toString());
+			} else {
+				boolean allGood = true;
+				final int rawTotal = attachments.size();
+				final int attTotal = rawTotal - 1; // See reason below.
+				// Start attCounter at 1 since the first element is always the
+				// item framework.
+				for (int attCounter = 1; attCounter < rawTotal; attCounter++) {
+					ResultsRow attRow = attachments.get(attCounter);
+					ReportManager.getInstance().getStats()
+							.incNumTotalAttachments();
+					logger.info(
+							"Processing item attachment [item#{}]-[att#{}] (out of [{}] attachments for this item)...",
+							itemCounter, attCounter, attTotal);
 
-          // Determine attachment status
-          if (attRow.getAttStatus().equals(ResultsRow.IGNORED)) {
-            // Consider not an error.
-            logger.info("Attachment {} is ignored.", attRow.getAttFilePath());
-            ReportManager.getInstance().getStats().incNumTotalAttachmentsIgnored();
-          } else if (doesAttachmentExist(attRow)) {
-            logger.info("Attachment {} is present.", attRow.getAttFilePath());
-            attRow.setAttStatus(ResultsRow.PRESENT);
-          } else {
-            logger.info("Attachment {} is missing.", attRow.getAttFilePath());
-            ReportManager.getInstance().getStats().incNumTotalAttachmentsMissing();
-            attRow.setAttStatus(ResultsRow.MISSING);
-            ReportManager.getInstance().errOutWriteln(attRow.toString());
-            allGood = false;
-          }
-          // Always send the attachment report to the standard file
-          // writer.
-          ReportManager.getInstance().stdOutWriteln(attRow.toString());
-        }
-        if (!allGood) {
-          ReportManager.getInstance().getStats().incNumTotalItemsAffected();
-        }
-      }
-    } catch (IOException e) {
-      // TODO - add to 'fatal errors' since returning false to stop the run
-      logger.fatal("Unrecoverable error while processing item - {}", e.getMessage(), e);
-      return false;
-    }
-    return true;
-  }
+					// Determine attachment status
+					if (attRow.getAttStatus().equals(ResultsRow.IGNORED)) {
+						// Consider not an error.
+						logger.info("Attachment {} is ignored.",
+								attRow.getAttFilePath());
+						ReportManager.getInstance().getStats()
+								.incNumTotalAttachmentsIgnored();
+					} else if (doesAttachmentExist(attRow)) {
+						logger.info("Attachment {} is present.",
+								attRow.getAttFilePath());
+						attRow.setAttStatus(ResultsRow.PRESENT);
+					} else {
+						logger.info("Attachment {} is missing.",
+								attRow.getAttFilePath());
+						ReportManager.getInstance().getStats()
+								.incNumTotalAttachmentsMissing();
+						attRow.setAttStatus(ResultsRow.MISSING);
+						ReportManager.getInstance().errOutWriteln(
+								attRow.toString());
+						allGood = false;
+					}
+					// Always send the attachment report to the standard file
+					// writer.
+					ReportManager.getInstance()
+							.stdOutWriteln(attRow.toString());
+				}
+				if (!allGood) {
+					ReportManager.getInstance().getStats()
+							.incNumTotalItemsAffected();
+				}
+			}
+		} catch (IOException e) {
+			// TODO - add to 'fatal errors' since returning false to stop the run
+			logger.fatal("Unrecoverable error while processing item - {}",
+					e.getMessage(), e);
+			return false;
+		}
+		return true;
+	}
 
-  private boolean doesAttachmentExist(ResultsRow attRow) {
-    int hash = attRow.getItemUuid().hashCode() & 127;
+	private boolean doesAttachmentExist(ResultsRow attRow) {
+		int hash = attRow.getItemUuid().hashCode() & 127;
 
-    String attPath =
-        String.format("/%d/%s/%s/", hash, attRow.getItemUuid(), attRow.getItemVersion());
+		String attPath = String.format("/%d/%s/%s/",
+						hash, attRow.getItemUuid(),
+						attRow.getItemVersion());
 
-    // Prevent odd encoding issues by not taking part in the format operation
-    // above.  Allow for a configured set of percent encoded values
-    String attName = attRow.getAttFilePath();
-    logger.debug("Original attachment name: [{}]", attName);
-    if (Config.getInstance().hasConfig(Config.CF_FILENAME_ENCODING_LIST)) {
-      for (String key :
-          Config.getInstance().getConfigAsStringArray(Config.CF_FILENAME_ENCODING_LIST)) {
-        final String original =
-            CheckFilesUtils.specialCharReplace(
-                Config.get(
-                    Config.CF_FILENAME_ENCODING_BASE + key + Config.CF_FILENAME_ENCODING_ORIGINAL));
-        final String result =
-            Config.get(Config.CF_FILENAME_ENCODING_BASE + key + Config.CF_FILENAME_ENCODING_RESULT);
-        logger.trace("Attachment replacement [{}]->[{}]", original, result);
-        attName = attName.replaceAll(original, result);
-        logger.trace(
-            "Attachment name after a replacement of [{}]->[{}]: [{}]", original, result, attName);
-      }
-    }
+		// Prevent odd encoding issues by not taking part in the format operation
+		// above.  Allow for a configured set of percent encoded values
+		String attName = attRow.getAttFilePath();
+		logger.debug("Original attachment name: [{}]", attName);
+		if(Config.getInstance().hasConfig(Config.CF_FILENAME_ENCODING_LIST)) {
+			for(String key : Config.getInstance().getConfigAsStringArray(Config.CF_FILENAME_ENCODING_LIST)) {
+				final String original = CheckFilesUtils.specialCharReplace(Config.get(Config.CF_FILENAME_ENCODING_BASE+key+Config.CF_FILENAME_ENCODING_ORIGINAL));
+				final String result = Config.get(Config.CF_FILENAME_ENCODING_BASE+key+Config.CF_FILENAME_ENCODING_RESULT);
+				logger.trace("Attachment replacement [{}]->[{}]", original, result);
+				attName = attName.replaceAll(original, result);
+				logger.trace("Attachment name after a replacement of [{}]->[{}]: [{}]", original, result, attName);
+			}
+		}
 
-    String basePath =
-        Config.get(Config.CF_FILESTORE_DIR)
-            + "/"
-            + institutionsById.get(attRow.getInstitutionId()).getFilestoreHandle()
-            + "/Attachments";
+		String basePath = Config.get(Config.CF_FILESTORE_DIR)+"/"+institutionsById.get(attRow.getInstitutionId())
+						.getFilestoreHandle()+"/Attachments";
 
-    // See if this attachment is in an 'advanced filestore'.
-    final String key =
-        Config.CF_FILESTORE_DIR_ADV + attRow.getInstitutionId() + "." + attRow.getCollectionUuid();
-    logger.debug(
-        "Checking if the attachment [{}][{}] has an associated adv filestore via the property [{}].",
-        attPath,
-        attName,
-        key);
-    if (Config.getInstance().hasConfig(key)) {
-      basePath = Config.get(key);
-    }
+		// See if this attachment is in an 'advanced filestore'.
+		final String key = Config.CF_FILESTORE_DIR_ADV+attRow.getInstitutionId()+"."+attRow.getCollectionUuid();
+		logger.debug("Checking if the attachment [{}][{}] has an associated adv filestore via the property [{}].", attPath, attName, key);
+		if(Config.getInstance().hasConfig(key)) {
+			basePath = Config.get(key);
+		}
 
-    final String path = basePath + attPath + attName;
-    final String altPath = basePath + "/" + attRow.getCollectionUuid() + attPath + attName;
+		final String path = basePath + attPath + attName;
+		final String altPath = basePath + "/" + attRow.getCollectionUuid() + attPath + attName;
 
-    if (Config.getInstance().hasConfig(key)) {
-      logger.info("Using advanced filestore path [{}] to check attachment.", path);
-    } else {
-      logger.info("Using path [{}] to check attachment.", path);
-    }
-    logger.info("Alt path [{}] to check attachment.", altPath);
+		if(Config.getInstance().hasConfig(key)) {
+			logger.info("Using advanced filestore path [{}] to check attachment.", path);
+		} else {
+			logger.info("Using path [{}] to check attachment.", path);
+		}
+		logger.info("Alt path [{}] to check attachment.", altPath);
 
-    if ((new File(path)).exists()) {
-      return true;
-    } else {
-      return (new File(altPath)).exists();
-    }
-  }
+		if((new File(path)).exists()) {
+			return true;
+		} else {
+			return (new File(altPath)).exists();
+		}
+	}
 
-  /**
-   * if there is a filter.by.institution.shortname specified, confirm there's a corresponding entry
-   * in the institution cache.
-   *
-   * <p>Sets a ReportManager fatal error if there isn't a corresponding entry.
-   *
-   * @return
-   */
-  private void confirmFilterByInstitution() {
-    String shortname = Config.get(Config.CF_FILTER_BY_INSTITUTION);
-    if (Check.isEmpty(shortname)) {
-      // non-existent / empty means check all institutions.
-      return;
-    }
+	/**
+	 * if there is a filter.by.institution.shortname specified, confirm there's
+	 * a corresponding entry in the institution cache.
+	 * 
+	 * Sets a ReportManager fatal error if there isn't a corresponding entry.
+	 * 
+	 * @return
+	 */
+	private void confirmFilterByInstitution() {
+		String shortname = Config.get(Config.CF_FILTER_BY_INSTITUTION);
+		if (Check.isEmpty(shortname)) {
+			// non-existent / empty means check all institutions.
+			return;
+		}
 
-    if (!institutionsByShortname.containsKey(shortname)) {
-      String msg =
-          String.format(
-              "The institution shortname to filter by [%s] is not in the institution cache.",
-              shortname);
-      logger.fatal(msg);
-      ReportManager.getInstance().addFatalError(msg);
-      return;
-    }
+		if (!institutionsByShortname.containsKey(shortname)) {
+			String msg = String
+					.format("The institution shortname to filter by [%s] is not in the institution cache.",
+							shortname);
+			logger.fatal(msg);
+			ReportManager.getInstance().addFatalError(msg);
+			return;
+		}
 
-    whereClauseExpressions.add(
-        new WhereClauseExpression(
-            "institution_id = ?",
-            institutionsByShortname.get(shortname).getId(),
-            whereClauseExpressions.size() + 1));
-  }
+		whereClauseExpressions.add(new WhereClauseExpression(
+				"institution_id = ?", institutionsByShortname.get(shortname)
+						.getId(), whereClauseExpressions.size() + 1));
+	}
 
-  /**
-   * Using the institution cache, determine if all filestores are accounted for.
-   *
-   * <p>Sets a ReportManager fatal error if there are any institutions without a corresponding
-   * filestore.
-   *
-   * @return
-   */
-  private void confirmAllInstitutionFilestores() {
-    String filter = Config.get(Config.CF_FILTER_BY_INSTITUTION);
-    for (String shortname : institutionsByShortname.keySet()) {
-      // filter == null >> looking at all institutions
-      // filter == shortname >> only check that institution filestore
-      // handle
-      if ((Check.isEmpty(filter) || filter.equals(shortname))) {
-        InstitutionRow ir = institutionsByShortname.get(shortname);
-        ir.setFilestoreHandle(shortname);
-        File instFilestore = new File(Config.get(Config.CF_FILESTORE_DIR), ir.getFilestoreHandle());
-        if (!instFilestore.exists()) {
-          logger.info(
-              "Institution filestore [{}] does not exist.  Checking for an alias...",
-              instFilestore.getAbsolutePath());
-          // Might have changed the filestore handle. The config
-          // should
-          // specify.
-          String handle = Config.getInstance().getFilestoreHandle(shortname);
-          if (handle == null || handle.isEmpty()) {
-            // Nothing specified. Fail.
-            String msg =
-                String.format(
-                    "Institution [%s] filestore handle is different than shortname, "
-                        + "but is not specified in the properties.",
-                    shortname);
-            ReportManager.getInstance().addFatalError(msg);
-            logger.error(msg);
-            return;
-          }
-          ir.setFilestoreHandle(handle);
-          instFilestore = new File(Config.get(Config.CF_FILESTORE_DIR), ir.getFilestoreHandle());
-          if (!instFilestore.exists()) {
-            // Bad handle. Fail.
-            String msg =
-                String.format(
-                    "Institution [%s] filestore handle is different than shortname, "
-                        + "but the handle (directory) specified in the properties [%s] does not exist.",
-                    shortname, handle);
-            ReportManager.getInstance().addFatalError(msg);
-            logger.error(msg);
-            return;
-          }
-        }
+	/**
+	 * Using the institution cache, determine if all filestores are accounted
+	 * for.
+	 * 
+	 * Sets a ReportManager fatal error if there are any institutions without a
+	 * corresponding filestore.
+	 * 
+	 * @return
+	 */
+	private void confirmAllInstitutionFilestores() {
+		String filter = Config.get(Config.CF_FILTER_BY_INSTITUTION);
+		for (String shortname : institutionsByShortname.keySet()) {
+			// filter == null >> looking at all institutions
+			// filter == shortname >> only check that institution filestore
+			// handle
+			if ((Check.isEmpty(filter) || filter.equals(shortname))) {
+				InstitutionRow ir = institutionsByShortname.get(shortname);
+				ir.setFilestoreHandle(shortname);
+				File instFilestore = new File(Config.get(Config.CF_FILESTORE_DIR), ir.getFilestoreHandle());
+				if (!instFilestore.exists()) {
+					logger.info(
+							"Institution filestore [{}] does not exist.  Checking for an alias...",
+							instFilestore.getAbsolutePath());
+					// Might have changed the filestore handle. The config
+					// should
+					// specify.
+					String handle = Config.getInstance().getFilestoreHandle(
+							shortname);
+					if (handle == null || handle.isEmpty()) {
+						// Nothing specified. Fail.
+						String msg = String
+								.format("Institution [%s] filestore handle is different than shortname, "
+										+ "but is not specified in the properties.",
+										shortname);
+						ReportManager.getInstance().addFatalError(msg);
+						logger.error(msg);
+						return;
+					}
+					ir.setFilestoreHandle(handle);
+					instFilestore = new File(Config.get(Config.CF_FILESTORE_DIR), ir.getFilestoreHandle());
+					if (!instFilestore.exists()) {
+						// Bad handle. Fail.
+						String msg = String
+								.format("Institution [%s] filestore handle is different than shortname, "
+										+ "but the handle (directory) specified in the properties [%s] does not exist.",
+										shortname, handle);
+						ReportManager.getInstance().addFatalError(msg);
+						logger.error(msg);
+						return;
+					}
+				}
 
-        // Check that the Attachments directory exists
-        File attsHandle = new File(instFilestore, "Attachments");
-        if (!attsHandle.exists()) {
-          // Bad handle. Fail.
-          String msg =
-              String.format(
-                  "Institution [%s] filestore attachments directory [%s] does not exist.",
-                  shortname, attsHandle.getAbsolutePath());
-          ReportManager.getInstance().addFatalError(msg);
-          logger.error(msg);
-          return;
-        }
+				// Check that the Attachments directory exists
+				File attsHandle = new File(instFilestore, "Attachments");
+				if (!attsHandle.exists()) {
+					// Bad handle. Fail.
+					String msg = String
+							.format("Institution [%s] filestore attachments directory [%s] does not exist.",
+									shortname, attsHandle.getAbsolutePath());
+					ReportManager.getInstance().addFatalError(msg);
+					logger.error(msg);
+					return;
+				}
 
-        if (!attsHandle.isDirectory()) {
-          // Bad handle. Fail.
-          String msg =
-              String.format(
-                  "Institution [{}] filestore attachments directory [{}] is not a directory.",
-                  shortname,
-                  attsHandle.getAbsolutePath());
-          ReportManager.getInstance().addFatalError(msg);
-          logger.error(msg);
-          return;
-        }
-      }
-    }
-  }
+				if (!attsHandle.isDirectory()) {
+					// Bad handle. Fail.
+					String msg = String
+							.format("Institution [{}] filestore attachments directory [{}] is not a directory.",
+									shortname, attsHandle.getAbsolutePath());
+					ReportManager.getInstance().addFatalError(msg);
+					logger.error(msg);
+					return;
+				}
+			}
+		}
+	}
 
-  private void setupDbConnection(String dbUrl, String un, String pw) {
-    try {
-      Class.forName("org.postgresql.Driver");
-      String connectionUrl = String.format("%s?user=%s&password=%s", dbUrl, un, pw);
-      con = DriverManager.getConnection(connectionUrl);
-      logger.info(String.format("Connected to %s", dbUrl));
-      con.setAutoCommit(false);
-      // Check the connection works.
-      String SQL = "SELECT id, uuid FROM item limit 1";
-      Statement stmt = con.createStatement();
-      long start = System.currentTimeMillis();
-      ResultSet rs = stmt.executeQuery(SQL);
-      boolean hasResults = rs.next();
-      rs.close();
-      long dur = System.currentTimeMillis() - start;
-      if (hasResults) {
-        logger.info("Confirmed DB connection in 0 ms.");
-        ReportManager.getInstance().getStats().queryRan(dur);
-        return;
-      } else {
-        String msg =
-            String.format(
-                "Unable to confirm connection to the DB [%s] with username [%s] and a password of length [%d]",
-                Config.get(Config.CF_DB_URL),
-                Config.get(Config.CF_DB_USERNAME),
-                Config.get(Config.CF_DB_PASSWORD).length());
-        logger.fatal(msg);
-        ReportManager.getInstance().addFatalError(msg);
-        return;
-      }
-    } catch (Exception e) {
-      String msg =
-          String.format(
-              "Unable to connect to the DB [%s] with username [%s] and a password of length [%d]",
-              Config.get(Config.CF_DB_URL),
-              Config.get(Config.CF_DB_USERNAME),
-              Config.get(Config.CF_DB_PASSWORD).length());
-      logger.fatal(msg, e);
-      ReportManager.getInstance().addFatalError(msg);
-      return;
-    }
-  }
+	private void setupDbConnection(
+			String dbUrl, String un, String pw) {
+		try {
+			Class.forName("org.postgresql.Driver");
+			String connectionUrl = String.format(
+					"%s?user=%s&password=%s",
+					dbUrl, un, pw);
+			con = DriverManager.getConnection(connectionUrl);
+			logger.info(String.format("Connected to %s",
+					dbUrl));
+			con.setAutoCommit(false);
+			// Check the connection works.
+			String SQL = "SELECT id, uuid FROM item limit 1";
+			Statement stmt = con.createStatement();
+			long start = System.currentTimeMillis();
+			ResultSet rs = stmt.executeQuery(SQL);
+			boolean hasResults = rs.next();
+			rs.close();
+			long dur = System.currentTimeMillis() - start;
+			if (hasResults) {
+				logger.info("Confirmed DB connection in 0 ms.");
+				ReportManager.getInstance().getStats().queryRan(dur);
+				return;
+			} else {
+				String msg = String.format(
+						"Unable to confirm connection to the DB [%s] with username [%s] and a password of length [%d]",
+						Config.get(Config.CF_DB_URL), Config.get(Config.CF_DB_USERNAME), Config.get(Config.CF_DB_PASSWORD).length());
+				logger.fatal(msg);
+				ReportManager.getInstance().addFatalError(msg);
+				return;
+			}
+		} catch (Exception e) {
+			String msg = String.format(
+					"Unable to connect to the DB [%s] with username [%s] and a password of length [%d]",
+							Config.get(Config.CF_DB_URL), Config.get(Config.CF_DB_USERNAME), Config.get(Config.CF_DB_PASSWORD).length());
+			logger.fatal(msg, e);
+			ReportManager.getInstance().addFatalError(msg);
+			return;
+		}
+	}
 
-  private boolean cacheAttachmentsPerItem() {
-    long start = System.currentTimeMillis();
-    int counter = 0;
-    try {
-      // For each item cached, query for the associated attachments.
-      for (List<ResultsRow> itemRowSet : attachmentsCache.values()) {
-        long batchStart = System.currentTimeMillis();
+	private boolean cacheAttachmentsPerItem() {
+		long start = System.currentTimeMillis();
+		int counter = 0;
+		try {
+			// For each item cached, query for the associated attachments.
+			for (List<ResultsRow> itemRowSet : attachmentsCache.values()) {
+				Pair<Boolean, Integer> result = cacheAttachmentsPerItem(itemRowSet.get(0).getItemId());
+				if(!result.getFirst()) {
+					return false;
+				}
+				counter += result.getSecond();
+			}
+		} catch (Exception e) {
+			logger.error("Unable to cache attachments (query per item) - {}",
+							e.getMessage(), e);
+			return false;
+		}
+		long dur = System.currentTimeMillis() - start;
+		logger.info("Cached {} attachments (query per item).  Duration {} ms.",
+						counter, dur);
+		ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
+		return true;
+	}
 
-        int itemId = itemRowSet.get(0).getItemId();
-        PreparedStatement stmt =
-            con.prepareStatement(
-                "select a.type, a.url, a.value1, a.uuid, a.id "
-                    + "from attachment a where a.item_id = ?");
-        stmt.setInt(1, itemId);
-        ResultSet rs = stmt.executeQuery();
-        while (rs.next()) {
-          counter++;
-          ResultsRow attRow =
-              inflateAttRow(
-                  rs.getString(1),
-                  rs.getString(2),
-                  rs.getString(3),
-                  rs.getString(4),
-                  rs.getInt(5),
-                  itemId);
-          // Note - at this point, attRow will not be null.
-          attachmentsCache.get(attRow.getItemId()).add(attRow);
-          logger.info("Attachment ({}) gathered: {}", counter, attRow.toString());
-        }
-        rs.close();
-        long batchDur = System.currentTimeMillis() - batchStart;
-        ReportManager.getInstance().getStats().queryRan(batchDur);
-        logger.debug("Cached a batch of attachments.  Duration {} ms.", batchDur);
-      }
-    } catch (Exception e) {
-      logger.error("Unable to cache attachments (query per item) - {}", e.getMessage(), e);
-      return false;
-    }
-    long dur = System.currentTimeMillis() - start;
-    logger.info("Cached {} attachments (query per item).  Duration {} ms.", counter, dur);
-    ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
-    return true;
-  }
+	private Pair<Boolean, Integer> cacheAttachmentsPerItem(int itemId) {
+		long start = System.currentTimeMillis();
+		int counter = 0;
+		try {
+			long batchStart = System.currentTimeMillis();
 
-  private boolean cacheAttachmentsAll() {
-    long start = System.currentTimeMillis();
-    int counter = 0;
-    try {
-      PreparedStatement stmt =
-          con.prepareStatement(
-              "select a.type, a.url, a.value1, a.uuid, a.id, a.item_id " + "from attachment a");
-      ResultSet rs = stmt.executeQuery();
-      // For each attachment, access the appropriate item attachment list
-      // and add the attachment
-      while (rs.next()) {
-        counter++;
-        ResultsRow attRow =
-            inflateAttRow(
-                rs.getString(1),
-                rs.getString(2),
-                rs.getString(3),
-                rs.getString(4),
-                rs.getInt(5),
-                rs.getInt(6));
-        if (attRow != null) {
-          attachmentsCache.get(attRow.getItemId()).add(attRow);
-          logger.info("Attachment ({}) gathered: {}", counter, attRow.toString());
-        }
-      }
-      rs.close();
-    } catch (Exception e) {
-      logger.error("Unable to cache attachments (single query) - {}", e.getMessage(), e);
-      return false;
-    }
-    long dur = System.currentTimeMillis() - start;
-    ReportManager.getInstance().getStats().queryRan(dur);
-    logger.info("Cached {} attachments (single query).  Duration {} ms.", counter, dur);
-    ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
-    return true;
-  }
+			PreparedStatement stmt = con
+					.prepareStatement("select a.type, a.url, a.value1, a.uuid, a.id "
+							+ "from attachment a where a.item_id = ?");
+			stmt.setInt(1, itemId);
+			ResultSet rs = stmt.executeQuery();
+			while (rs.next()) {
+				counter++;
+				ResultsRow attRow = inflateAttRow(rs.getString(1),
+						rs.getString(2), rs.getString(3), rs.getString(4),
+						rs.getInt(5), itemId);
+				// Note - at this point, attRow will not be null.
+				attachmentsCache.get(attRow.getItemId()).add(attRow);
+				logger.info("Attachment ({}) gathered: {}", counter,
+						attRow.toString());
+			}
+			rs.close();
+			long batchDur = System.currentTimeMillis() - batchStart;
+			ReportManager.getInstance().getStats().queryRan(batchDur);
+			logger.debug("Cached a batch of attachments.  Duration {} ms.",
+					batchDur);
+		} catch (Exception e) {
+			logger.error("Unable to cache attachments (query per item) - {}",
+					e.getMessage(), e);
+			return Pair.pair(false, counter);
+		}
+		long dur = System.currentTimeMillis() - start;
+		logger.info("Cached {} attachments (query per item).  Duration {} ms.",
+				counter, dur);
+		ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
+		return Pair.pair(true, counter);
+	}
 
-  private ResultsRow inflateAttRow(
-      String attType, String attUrl, String value1, String attUuid, int attId, int itemId) {
-    // If an attachment was found without the parent item, log a
-    // warning, but effectively ignore.
-    if (!attachmentsCache.containsKey(itemId)) {
-      logger.warn(
-          "Found an attachment whose itemId DOES NOT EXIST in the item cache.  "
-              + "Ignoring (not caching): type=[{}], url=[{}], value1=[{}], uuid=[{}], attId=[{}], itemId=[{}]",
-          attType,
-          attUrl,
-          value1,
-          attUuid,
-          attId,
-          itemId);
-      return null;
-    }
+	private boolean cacheAttachmentsAll() {
+		long start = System.currentTimeMillis();
+		int counter = 0;
+		try {
+			PreparedStatement stmt = con
+					.prepareStatement("select a.type, a.url, a.value1, a.uuid, a.id, a.item_id "
+							+ "from attachment a");
+			ResultSet rs = stmt.executeQuery();
+			// For each attachment, access the appropriate item attachment list
+			// and add the attachment
+			while (rs.next()) {
+				counter++;
+				ResultsRow attRow = inflateAttRow(rs.getString(1),
+						rs.getString(2), rs.getString(3), rs.getString(4),
+						rs.getInt(5), rs.getInt(6));
+				if (attRow != null) {
+					attachmentsCache.get(attRow.getItemId()).add(attRow);
+					logger.info("Attachment ({}) gathered: {}", counter,
+							attRow.toString());
+				}
+			}
+			rs.close();
+		} catch (Exception e) {
+			logger.error("Unable to cache attachments (single query) - {}",
+					e.getMessage(), e);
+			return false;
+		}
+		long dur = System.currentTimeMillis() - start;
+		ReportManager.getInstance().getStats().queryRan(dur);
+		logger.info("Cached {} attachments (single query).  Duration {} ms.",
+				counter, dur);
+		ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
+		return true;
+	}
 
-    // Build out the general attributes
-    ResultsRow attRow = ResultsRow.buildItemFrame(attachmentsCache.get(itemId).get(0));
+	private ResultsRow inflateAttRow(String attType, String attUrl,
+			String value1, String attUuid, int attId, int itemId) {
+		// If an attachment was found without the parent item, log a
+		// warning, but effectively ignore.
+		if (!attachmentsCache.containsKey(itemId)) {
+			logger.warn(
+					"Found an attachment whose itemId DOES NOT EXIST in the item cache.  "
+							+ "Ignoring (not caching): type=[{}], url=[{}], value1=[{}], uuid=[{}], attId=[{}], itemId=[{}]",
+					attType, attUrl, value1, attUuid, attId, itemId);
+			return null;
+		}
 
-    // inflate the static metadata
-    attRow.setAttId(attId);
-    attRow.setAttUuid(attUuid);
-    attRow.setAttUrl(attUrl);
-    attRow.setAttType(attType);
+		// Build out the general attributes
+		ResultsRow attRow = ResultsRow.buildItemFrame(attachmentsCache.get(
+				itemId).get(0));
 
-    // Determine the filestore
-    if (attRow.getAttType().equals("file")) {
-      attRow.setAttFilePath(attRow.getAttUrl());
-    } else if (attRow.getAttType().equals("zip")) {
-      attRow.setAttFilePath(attRow.getAttUrl());
-    } else if (attRow.getAttType().equals("html")) {
-      attRow.setAttFilePath(String.format("_mypages/%s/page.html", attRow.getAttUuid()));
-    } else if (attRow.getAttType().equals("custom") && value1.equals("scorm")) {
-      attRow.setAttType("scorm");
-      // Unsupported for now.
-      // filepath = String.format("_IMS/%s", attRow.getAttUrl());
-      attRow.setAttStatus(ResultsRow.IGNORED);
-    } else {
-      // Ignore all other attachments (URLs, Flickr, Equella resources,
-      // etc)
-      attRow.setAttStatus(ResultsRow.IGNORED);
-    }
+		// inflate the static metadata
+		attRow.setAttId(attId);
+		attRow.setAttUuid(attUuid);
+		attRow.setAttUrl(attUrl);
+		attRow.setAttType(attType);
 
-    return attRow;
-  }
+		// Determine the filestore
+		if (attRow.getAttType().equals("file")) {
+			attRow.setAttFilePath(attRow.getAttUrl());
+		} else if (attRow.getAttType().equals("zip")) {
+			attRow.setAttFilePath(attRow.getAttUrl());
+		} else if (attRow.getAttType().equals("html")) {
+			attRow.setAttFilePath(String.format("_mypages/%s/page.html",
+					attRow.getAttUuid()));
+		} else if (attRow.getAttType().equals("custom")
+				&& value1.equals("scorm")) {
+			attRow.setAttType("scorm");
+			// Unsupported for now.
+			// filepath = String.format("_IMS/%s", attRow.getAttUrl());
+			attRow.setAttStatus(ResultsRow.IGNORED);
+		} else {
+			// Ignore all other attachments (URLs, Flickr, Equella resources,
+			// etc)
+			attRow.setAttStatus(ResultsRow.IGNORED);
+		}
 
-  private void cacheCollections() {
-    long start = System.currentTimeMillis();
-    try {
-      PreparedStatement stmt =
-          con.prepareStatement(
-              "select c.id, e.uuid, e.institution_id "
-                  + "from item_definition c "
-                  + "inner join base_entity e on c.id = e.id");
-      ResultSet rs = stmt.executeQuery();
-      while (rs.next()) {
-        CollectionRow cr = new CollectionRow();
-        cr.setId(rs.getInt(1));
-        cr.setInstitutionId(rs.getInt(3));
-        cr.setUuid(rs.getString(2));
+		return attRow;
+	}
 
-        collectionsById.put(cr.getId(), cr);
-        // collectionsByUuid.put(rs.getString(2), rs.getInt(1));
-        logger.info("Cached collection:  {}", cr.toString());
-      }
-      rs.close();
-    } catch (Exception e) {
-      String msg = String.format("Unable to cache collections - %s", e.getMessage());
-      logger.fatal(msg, e);
-      ReportManager.getInstance().addFatalError(msg);
-      return;
-    }
-    long dur = System.currentTimeMillis() - start;
-    ReportManager.getInstance().getStats().queryRan(dur);
-    logger.info("Cached collections.  Duration {} ms.", dur);
-    return;
-  }
+	private void cacheCollections() {
+		long start = System.currentTimeMillis();
+		try {
+			PreparedStatement stmt = con
+					.prepareStatement("select c.id, e.uuid, e.institution_id "
+							+ "from item_definition c "
+							+ "inner join base_entity e on c.id = e.id");
+			ResultSet rs = stmt.executeQuery();
+			while (rs.next()) {
+				CollectionRow cr = new CollectionRow();
+				cr.setId(rs.getInt(1));
+				cr.setInstitutionId(rs.getInt(3));
+				cr.setUuid(rs.getString(2));
 
-  private void cacheInstitutions() {
-    long start = System.currentTimeMillis();
-    try {
-      PreparedStatement stmt =
-          con.prepareStatement(
-              "select i.id, i.short_name, i.name, i.unique_id, i.url "
-                  + "from institution i order by i.short_name");
-      ResultSet rs = stmt.executeQuery();
-      while (rs.next()) {
-        InstitutionRow ir = new InstitutionRow();
-        ir.setId(rs.getInt(1));
-        ir.setShortname(rs.getString(2));
-        ir.setName(rs.getString(3));
-        ir.setUniqueId(rs.getString(4));
-        ir.setUrl(rs.getString(5));
-        institutionsByShortname.put(ir.getShortname(), ir);
-        institutionsById.put(ir.getId(), ir);
-        logger.info("Cached institution: {}", ir.toString());
-      }
-      rs.close();
-    } catch (Exception e) {
-      String msg = String.format("Unable to cache institutions - %s", e.getMessage());
-      logger.fatal(msg, e);
-      ReportManager.getInstance().addFatalError(msg);
-      return;
-    }
-    long dur = System.currentTimeMillis() - start;
-    ReportManager.getInstance().getStats().queryRan(dur);
-    logger.info("Cached institutions.  Duration {} ms.", dur);
-    return;
-  }
+				collectionsById.put(cr.getId(), cr);
+				// collectionsByUuid.put(rs.getString(2), rs.getInt(1));
+				logger.info("Cached collection:  {}", cr.toString());
+			}
+			rs.close();
+		} catch (Exception e) {
+			String msg = String.format("Unable to cache collections - %s",
+					e.getMessage());
+			logger.fatal(msg, e);
+			ReportManager.getInstance().addFatalError(msg);
+			return;
+		}
+		long dur = System.currentTimeMillis() - start;
+		ReportManager.getInstance().getStats().queryRan(dur);
+		logger.info("Cached collections.  Duration {} ms.", dur);
+		return;
+	}
 
-  private void confirmFilterByCollection() {
-    if (Check.isEmpty(Config.get(Config.CF_FILTER_BY_COLLECTION))) {
-      logger.info("Filter by collection ID not specified.  Not filtering by collection");
-      return;
-    }
+	private void cacheInstitutions() {
+		long start = System.currentTimeMillis();
+		try {
+			PreparedStatement stmt = con
+					.prepareStatement("select i.id, i.short_name, i.name, i.unique_id, i.url "
+							+ "from institution i order by i.short_name");
+			ResultSet rs = stmt.executeQuery();
+			while (rs.next()) {
+				InstitutionRow ir = new InstitutionRow();
+				ir.setId(rs.getInt(1));
+				ir.setShortname(rs.getString(2));
+				ir.setName(rs.getString(3));
+				ir.setUniqueId(rs.getString(4));
+				ir.setUrl(rs.getString(5));
+				institutionsByShortname.put(ir.getShortname(), ir);
+				institutionsById.put(ir.getId(), ir);
+				logger.info("Cached institution: {}", ir.toString());
+			}
+			rs.close();
+		} catch (Exception e) {
+			String msg = String.format("Unable to cache institutions - %s",
+					e.getMessage());
+			logger.fatal(msg, e);
+			ReportManager.getInstance().addFatalError(msg);
+			return;
+		}
+		long dur = System.currentTimeMillis() - start;
+		ReportManager.getInstance().getStats().queryRan(dur);
+		logger.info("Cached institutions.  Duration {} ms.", dur);
+		return;
+	}
 
-    final int id = Config.getInstance().getConfigAsInt(Config.CF_FILTER_BY_COLLECTION);
-    if (!collectionsById.containsKey(id)) {
-      String msg =
-          String.format(
-              "Unable to find the collection ID [%s].  Not a valid filter.",
-              Config.get(Config.CF_FILTER_BY_COLLECTION));
-      logger.fatal(msg);
-      ReportManager.getInstance().addFatalError(msg);
-      return;
-    }
+	private void confirmFilterByCollection() {
+		if (Check.isEmpty(Config.get(Config.CF_FILTER_BY_COLLECTION))) {
+			logger.info("Filter by collection ID not specified.  Not filtering by collection");
+			return;
+		}
 
-    whereClauseExpressions.add(
-        new WhereClauseExpression("item_definition_id = ?", id, whereClauseExpressions.size() + 1));
-  }
+		final int id = Config.getInstance().getConfigAsInt(Config.CF_FILTER_BY_COLLECTION);
+		if (!collectionsById.containsKey(id)) {
+			String msg = String
+					.format("Unable to find the collection ID [%s].  Not a valid filter.",
+							Config.get(Config.CF_FILTER_BY_COLLECTION));
+			logger.fatal(msg);
+			ReportManager.getInstance().addFatalError(msg);
+			return;
+		}
 
-  private boolean cacheItemsAll() {
-    long start = System.currentTimeMillis();
-    try {
-      PreparedStatement stmt =
-          con.prepareStatement(
-              String.format(
-                  "select id, uuid, version, status, item_definition_id, institution_id from item %s order by id",
-                  WhereClauseExpression.makeWhereClause(whereClauseExpressions)));
-      WhereClauseExpression.setParms(stmt, whereClauseExpressions);
+		whereClauseExpressions.add(new WhereClauseExpression(
+				"item_definition_id = ?", id, whereClauseExpressions
+						.size() + 1));
+	}
 
-      ResultSet rs = stmt.executeQuery();
-      while (rs.next()) {
-        ResultsRow itemRow = new ResultsRow();
-        itemRow.setItemId(rs.getInt(1));
-        itemRow.setItemUuid(rs.getString(2));
-        itemRow.setItemVersion("" + rs.getInt(3));
-        itemRow.setItemStatus(rs.getString(4));
-        int collId = rs.getInt(5);
-        if (collectionsById.containsKey(collId)) {
-          itemRow.setCollectionUuid(collectionsById.get(collId).getUuid());
-        } else {
-          logger.warn(
-              "Expected collection ID [{}] not cached for item {}/{}.",
-              collId,
-              itemRow.getItemUuid(),
-              itemRow.getItemVersion());
-          itemRow.setCollectionUuid("" + collId);
-        }
-        itemRow.setInstitutionId(rs.getInt(6));
-        itemRow.setInstitutionShortname(
-            institutionsById.get(itemRow.getInstitutionId()).getShortname());
-        List<ResultsRow> seeder = new ArrayList<ResultsRow>();
-        seeder.add(itemRow);
-        attachmentsCache.put(itemRow.getItemId(), seeder);
+	private boolean cacheItemsAll() {
+		long start = System.currentTimeMillis();
+		try {
+			PreparedStatement stmt = con
+					.prepareStatement(String
+							.format("select id, uuid, version, status, item_definition_id, institution_id from item %s order by id",
+									WhereClauseExpression
+											.makeWhereClause(whereClauseExpressions)));
+			WhereClauseExpression.setParms(stmt, whereClauseExpressions);
 
-        logger.info("Found [{}] item:  {}", (attachmentsCache.size()), itemRow.toString());
-      }
-      rs.close();
-    } catch (Exception e) {
-      logger.error("Unable to cache items (single query) - {}", e.getMessage(), e);
-      return false;
-    }
-    long dur = System.currentTimeMillis() - start;
-    ReportManager.getInstance().getStats().queryRan(dur);
-    logger.info("Cached items (single query).  Duration {} ms.", dur);
-    ReportManager.getInstance().getStats().incNumGrandTotalItems(attachmentsCache.size());
-    return true;
-  }
+			ResultSet rs = stmt.executeQuery();
+			while (rs.next()) {
+				ResultsRow itemRow = new ResultsRow();
+				itemRow.setItemId(rs.getInt(1));
+				itemRow.setItemUuid(rs.getString(2));
+				itemRow.setItemVersion("" + rs.getInt(3));
+				itemRow.setItemStatus(rs.getString(4));
+				int collId = rs.getInt(5);
+				if (collectionsById.containsKey(collId)) {
+					itemRow.setCollectionUuid(collectionsById.get(collId)
+							.getUuid());
+				} else {
+					logger.warn(
+							"Expected collection ID [{}] not cached for item {}/{}.",
+							collId, itemRow.getItemUuid(),
+							itemRow.getItemVersion());
+					itemRow.setCollectionUuid("" + collId);
+				}
+				itemRow.setInstitutionId(rs.getInt(6));
+				itemRow.setInstitutionShortname(institutionsById.get(
+						itemRow.getInstitutionId()).getShortname());
+				List<ResultsRow> seeder = new ArrayList<ResultsRow>();
+				seeder.add(itemRow);
+				attachmentsCache.put(itemRow.getItemId(), seeder);
 
-  /**
-   * Fails in SQL Server 2008. Works in SQL Server 2012.
-   *
-   * @return
-   */
-  private boolean cacheItemsBatched() {
-    long start = System.currentTimeMillis();
-    try {
-      String sql =
-          String.format(
-              "select id, uuid, version, status, item_definition_id, institution_id from item %s order by id OFFSET ? ROWS FETCH NEXT ? ROWS ONLY",
-              WhereClauseExpression.makeWhereClause(whereClauseExpressions));
-      logger.debug("SQL:  [{}]", sql);
-      int offsetCounter = 0;
-      boolean hasMore = false;
-      do {
-        // Assume no rows are returned.
-        hasMore = false;
-        long batchStart = System.currentTimeMillis();
+				logger.info("Found [{}] item:  {}", (attachmentsCache.size()),
+						itemRow.toString());
+			}
+			rs.close();
+		} catch (Exception e) {
+			logger.error("Unable to cache items (single query) - {}",
+					e.getMessage(), e);
+			return false;
+		}
+		long dur = System.currentTimeMillis() - start;
+		ReportManager.getInstance().getStats().queryRan(dur);
+		logger.info("Cached items (single query).  Duration {} ms.", dur);
+		ReportManager.getInstance().getStats().incNumGrandTotalItems(attachmentsCache.size());
+		return true;
+	}
 
-        PreparedStatement stmt = con.prepareStatement(sql);
-        WhereClauseExpression.setParms(stmt, whereClauseExpressions);
-        stmt.setInt(
-            whereClauseExpressions.size() + 1,
-            offsetCounter * Config.getInstance().getConfigAsInt(Config.CF_NUM_OF_ITEMS_PER_QUERY));
-        stmt.setInt(
-            whereClauseExpressions.size() + 2,
-            Config.getInstance().getConfigAsInt(Config.CF_NUM_OF_ITEMS_PER_QUERY));
-        ResultSet rs = stmt.executeQuery();
-        while (rs.next()) {
-          hasMore = true;
-          ResultsRow itemRow = new ResultsRow();
-          itemRow.setItemId(rs.getInt(1));
-          itemRow.setItemUuid(rs.getString(2));
-          itemRow.setItemVersion("" + rs.getInt(3));
-          itemRow.setItemStatus(rs.getString(4));
-          int collId = rs.getInt(5);
-          if (collectionsById.containsKey(collId)) {
-            itemRow.setCollectionUuid(collectionsById.get(collId).getUuid());
-          } else {
-            logger.warn(
-                "Expected collection ID [{}] not cached for item {}/{}.",
-                collId,
-                itemRow.getItemUuid(),
-                itemRow.getItemVersion());
-            itemRow.setCollectionUuid("" + collId);
-          }
-          itemRow.setInstitutionId(rs.getInt(6));
-          itemRow.setInstitutionShortname(
-              institutionsById.get(itemRow.getInstitutionId()).getShortname());
+	/**
+	 * Fails in SQL Server 2008. Works in SQL Server 2012.
+	 * 
+	 * @return
+	 */
+	private boolean cacheItemsBatched(boolean confirmInline) {
+		long start = System.currentTimeMillis();
+		try {
+			String sql = String
+					.format("select id, uuid, version, status, item_definition_id, institution_id from item %s order by id OFFSET ? ROWS FETCH NEXT ? ROWS ONLY",
+							WhereClauseExpression
+									.makeWhereClause(whereClauseExpressions));
+			logger.debug("SQL:  [{}]", sql);
+			int offsetCounter = 0;
+			boolean hasMore = false;
+			do {
+				// Assume no rows are returned.
+				hasMore = false;
+				long batchStart = System.currentTimeMillis();
 
-          List<ResultsRow> seeder = new ArrayList<ResultsRow>();
-          seeder.add(itemRow);
-          attachmentsCache.put(itemRow.getItemId(), seeder);
+				PreparedStatement stmt = con.prepareStatement(sql);
+				WhereClauseExpression.setParms(stmt, whereClauseExpressions);
+				stmt.setInt(whereClauseExpressions.size() + 1, offsetCounter
+						* Config.getInstance().getConfigAsInt(Config.CF_NUM_OF_ITEMS_PER_QUERY));
+				stmt.setInt(whereClauseExpressions.size() + 2, Config.getInstance().getConfigAsInt(Config.CF_NUM_OF_ITEMS_PER_QUERY));
+				ResultSet rs = stmt.executeQuery();
+				while (rs.next()) {
+					hasMore = true;
+					ResultsRow itemRow = new ResultsRow();
+					itemRow.setItemId(rs.getInt(1));
+					itemRow.setItemUuid(rs.getString(2));
+					itemRow.setItemVersion("" + rs.getInt(3));
+					itemRow.setItemStatus(rs.getString(4));
+					int collId = rs.getInt(5);
+					if (collectionsById.containsKey(collId)) {
+						itemRow.setCollectionUuid(collectionsById.get(collId)
+								.getUuid());
+					} else {
+						logger.warn(
+								"Expected collection ID [{}] not cached for item {}/{}.",
+								collId, itemRow.getItemUuid(),
+								itemRow.getItemVersion());
+						itemRow.setCollectionUuid("" + collId);
+					}
+					itemRow.setInstitutionId(rs.getInt(6));
+					itemRow.setInstitutionShortname(institutionsById.get(
+							itemRow.getInstitutionId()).getShortname());
 
-          logger.info("Found the [{}]th item:  {}", (attachmentsCache.size()), itemRow.toString());
-        }
-        rs.close();
-        offsetCounter++;
-        long batchDur = System.currentTimeMillis() - batchStart;
-        ReportManager.getInstance().getStats().queryRan(batchDur);
-        if (hasMore) {
-          logger.info("Cached a batch of items.  Duration {} ms.", batchDur);
-        } else {
-          logger.info("No more batches of items found to cache.  Duration {} ms.", batchDur);
-        }
+					List<ResultsRow> seeder = new ArrayList<ResultsRow>();
+					seeder.add(itemRow);
+					attachmentsCache.put(itemRow.getItemId(), seeder);
 
-      } while (hasMore);
-    } catch (Exception e) {
-      logger.error("Unable to cache items (batched queries) - {}", e.getMessage(), e);
-      return false;
-    }
-    long dur = System.currentTimeMillis() - start;
-    logger.info("Cached items (batched queries).  Total duration {} ms.", dur);
-    ReportManager.getInstance().getStats().incNumGrandTotalItems(attachmentsCache.size());
-    return true;
-  }
+					logger.info("Found the [{}]th item:  {}",
+							(attachmentsCache.size()), itemRow.toString());
+					if(confirmInline) {
+						Pair<Boolean, Integer> result = cacheAttachmentsPerItem(itemRow.getItemId());
+						if(result.getFirst()) {
+							if(!processItem(itemRow.getItemId(), attachmentsCache.size())) {
+								rs.close();
+								throw new Exception("Unable to check attachments for item [" + itemRow.getItemId() + "]");
+							}
+						} else {
+							rs.close();
+							throw new Exception("Unable to cache attachments for item [" + itemRow.getItemId() + "]");
+						}
+					}
+				}
+				rs.close();
+				offsetCounter++;
+				long batchDur = System.currentTimeMillis() - batchStart;
+				ReportManager.getInstance().getStats().queryRan(batchDur);
+				if (hasMore) {
+					logger.info("Cached a batch of items.  Duration {} ms.",
+							batchDur);
+				} else {
+					logger.info(
+							"No more batches of items found to cache.  Duration {} ms.",
+							batchDur);
+				}
+
+			} while (hasMore);
+		} catch (Exception e) {
+			logger.error("Unable to cache items (batched queries) - {}",
+					e.getMessage(), e);
+			return false;
+		}
+		long dur = System.currentTimeMillis() - start;
+		logger.info("Cached items (batched queries).  Total duration {} ms.",
+				dur);
+		ReportManager.getInstance().getStats().incNumGrandTotalItems(attachmentsCache.size());
+		return true;
+	}
 }

--- a/src/main/java/org/apereo/openequella/tools/toolbox/checkFiles/CheckFilesDbHandler.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/checkFiles/CheckFilesDbHandler.java
@@ -35,7 +35,6 @@ import org.apache.logging.log4j.Logger;
 import org.apereo.openequella.tools.toolbox.Config;
 import org.apereo.openequella.tools.toolbox.utils.Check;
 import org.apereo.openequella.tools.toolbox.utils.CheckFilesUtils;
-import org.apereo.openequella.tools.toolbox.utils.FileUtils;
 import org.apereo.openequella.tools.toolbox.utils.Pair;
 import org.apereo.openequella.tools.toolbox.utils.WhereClauseExpression;
 
@@ -45,764 +44,777 @@ import org.apereo.openequella.tools.toolbox.utils.WhereClauseExpression;
  * the uuid / version 's filestore.
  */
 public class CheckFilesDbHandler {
-	private static final Logger logger = LogManager
-			.getLogger(CheckFilesDbHandler.class);
+  private static final Logger logger = LogManager.getLogger(CheckFilesDbHandler.class);
 
-	private Connection con;
-	private Map<Integer, CollectionRow> collectionsById = new HashMap<Integer, CollectionRow>();
-	private Map<String, InstitutionRow> institutionsByShortname = new HashMap<String, InstitutionRow>();
-	private Map<Integer, InstitutionRow> institutionsById = new HashMap<Integer, InstitutionRow>();
-	// item id is the key. First ResultsRow in the cache list is the item
-	// details.
-	private Map<Integer, List<ResultsRow>> attachmentsCache = new HashMap<Integer, List<ResultsRow>>();
+  private Connection con;
+  private Map<Integer, CollectionRow> collectionsById = new HashMap<Integer, CollectionRow>();
+  private Map<String, InstitutionRow> institutionsByShortname =
+      new HashMap<String, InstitutionRow>();
+  private Map<Integer, InstitutionRow> institutionsById = new HashMap<Integer, InstitutionRow>();
+  // item id is the key. First ResultsRow in the cache list is the item
+  // details.
+  private Map<Integer, List<ResultsRow>> attachmentsCache =
+      new HashMap<Integer, List<ResultsRow>>();
 
-	private List<WhereClauseExpression> whereClauseExpressions = new ArrayList<WhereClauseExpression>();
+  private List<WhereClauseExpression> whereClauseExpressions =
+      new ArrayList<WhereClauseExpression>();
 
-	public boolean execute() {
-		// Setup database connection
-		setupDbConnection(Config.get(Config.CF_DB_URL),
-				Config.get(Config.CF_DB_USERNAME), Config
-						.get(Config.CF_DB_PASSWORD));
-		if(ReportManager.getInstance().hasFatalErrors()) {
-			closeConnection();
-			return false;
-		}
+  public boolean execute() {
+    // Setup database connection
+    setupDbConnection(
+        Config.get(Config.CF_DB_URL),
+        Config.get(Config.CF_DB_USERNAME),
+        Config.get(Config.CF_DB_PASSWORD));
+    if (ReportManager.getInstance().hasFatalErrors()) {
+      closeConnection();
+      return false;
+    }
 
-		cacheCollections();
-		if(ReportManager.getInstance().hasFatalErrors()) {
-			closeConnection();
-			return false;
-		}
+    cacheCollections();
+    if (ReportManager.getInstance().hasFatalErrors()) {
+      closeConnection();
+      return false;
+    }
 
-		cacheInstitutions();
-		if(ReportManager.getInstance().hasFatalErrors()) {
-			closeConnection();
-			return false;
-		}
+    cacheInstitutions();
+    if (ReportManager.getInstance().hasFatalErrors()) {
+      closeConnection();
+      return false;
+    }
 
-		confirmFilterByCollection();
-		if(ReportManager.getInstance().hasFatalErrors()) {
-			closeConnection();
-			return false;
-		}
+    confirmFilterByCollection();
+    if (ReportManager.getInstance().hasFatalErrors()) {
+      closeConnection();
+      return false;
+    }
 
-		confirmFilterByInstitution();
-		if (ReportManager.getInstance().hasFatalErrors()) {
-			closeConnection();
-			return false;
-		}
+    confirmFilterByInstitution();
+    if (ReportManager.getInstance().hasFatalErrors()) {
+      closeConnection();
+      return false;
+    }
 
-		confirmAllInstitutionFilestores();
-		if (ReportManager.getInstance().hasFatalErrors()) {
-			closeConnection();
-			return false;
-		}
+    confirmAllInstitutionFilestores();
+    if (ReportManager.getInstance().hasFatalErrors()) {
+      closeConnection();
+      return false;
+    }
 
-		if (!ReportManager.getInstance().setupReportDetails()) {
-			closeConnection();
-			return false;
-		}
+    if (!ReportManager.getInstance().setupReportDetails()) {
+      closeConnection();
+      return false;
+    }
 
-		if(Config.CheckFilesType.valueOf(Config.get(Config.CF_MODE)) == Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE) {
-			if (!cacheItemsBatched(true)) {
-				closeConnection();
-				return false;
-			}
-		} else {
-			// Cache Items
-			if (Config.get(Config.CF_MODE).contains("ALL_ITEMS")) {
-				if (!cacheItemsAll()) {
-					closeConnection();
-					return false;
-				}
-			} else {
-				if (!cacheItemsBatched(false)) {
-					closeConnection();
-					return false;
-				}
-			}
+    if (Config.CheckFilesType.valueOf(Config.get(Config.CF_MODE))
+        == Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE) {
+      if (!cacheItemsBatched(true)) {
+        closeConnection();
+        return false;
+      }
+    } else {
+      // Cache Items
+      if (Config.get(Config.CF_MODE).contains("ALL_ITEMS")) {
+        if (!cacheItemsAll()) {
+          closeConnection();
+          return false;
+        }
+      } else {
+        if (!cacheItemsBatched(false)) {
+          closeConnection();
+          return false;
+        }
+      }
 
-			// Cache Attachments
-			if (Config.get(Config.CF_MODE).endsWith("ALL_ATTACHMENTS")) {
-				if (!cacheAttachmentsAll()) {
-					closeConnection();
-					return false;
-				}
-			} else {
-				if (!cacheAttachmentsPerItem()) {
-					closeConnection();
-					return false;
-				}
-			}
+      // Cache Attachments
+      if (Config.get(Config.CF_MODE).endsWith("ALL_ATTACHMENTS")) {
+        if (!cacheAttachmentsAll()) {
+          closeConnection();
+          return false;
+        }
+      } else {
+        if (!cacheAttachmentsPerItem()) {
+          closeConnection();
+          return false;
+        }
+      }
 
-			// Check attachments one item at a time
-			int counter = 0;
-			for (Integer itemId : attachmentsCache.keySet()) {
-				counter++;
-				if (!processItem(itemId, counter)) {
-					closeConnection();
-					return false;
-				}
-			}
-		}
+      // Check attachments one item at a time
+      int counter = 0;
+      for (Integer itemId : attachmentsCache.keySet()) {
+        counter++;
+        if (!processItem(itemId, counter)) {
+          closeConnection();
+          return false;
+        }
+      }
+    }
 
-		closeConnection();
-		return true;
-	}
+    closeConnection();
+    return true;
+  }
 
-	private boolean closeConnection() {
-		try {
-			if (con != null) {
-				con.close();
-				logger.debug("Closed DB connection");
-			}
-			return true;
-		} catch (SQLException e) {
-			logger.error("Unable to close connection due to {}",
-					e.getMessage(), e);
-			return false;
-		}
-	}
+  private boolean closeConnection() {
+    try {
+      if (con != null) {
+        con.close();
+        logger.debug("Closed DB connection");
+      }
+      return true;
+    } catch (SQLException e) {
+      logger.error("Unable to close connection due to {}", e.getMessage(), e);
+      return false;
+    }
+  }
 
-	/**
-	 * 
-	 * @param itemId
-	 *            assumes this exists in the cache.
-	 * @param itemCounter
-	 *            item counter
-	 * @return
-	 */
-	private boolean processItem(int itemId, int itemCounter) {
-		try {
-			logger.info("Processing item [{}]...", itemCounter);
-			ReportManager.getInstance().getStats().incNumTotalItems();
+  /**
+   * @param itemId assumes this exists in the cache.
+   * @param itemCounter item counter
+   * @return
+   */
+  private boolean processItem(int itemId, int itemCounter) {
+    try {
+      logger.info("Processing item [{}]...", itemCounter);
+      ReportManager.getInstance().getStats().incNumTotalItems();
 
-			List<ResultsRow> attachments = attachmentsCache.get(itemId);
-			// Remember, the attachmentsCache for an item is always seeded with
-			// an 'item' results row.
-			// If there is only the seeded ResultsRow, there were no attachments
-			// found.
-			if (attachments.size() == 1) {
-				attachments.get(0).setAttStatus(ResultsRow.NOATT);
-				ReportManager.getInstance().stdOutWriteln(
-						attachments.get(0).toString());
-			} else {
-				boolean allGood = true;
-				final int rawTotal = attachments.size();
-				final int attTotal = rawTotal - 1; // See reason below.
-				// Start attCounter at 1 since the first element is always the
-				// item framework.
-				for (int attCounter = 1; attCounter < rawTotal; attCounter++) {
-					ResultsRow attRow = attachments.get(attCounter);
-					ReportManager.getInstance().getStats()
-							.incNumTotalAttachments();
-					logger.info(
-							"Processing item attachment [item#{}]-[att#{}] (out of [{}] attachments for this item)...",
-							itemCounter, attCounter, attTotal);
+      List<ResultsRow> attachments = attachmentsCache.get(itemId);
+      // Remember, the attachmentsCache for an item is always seeded with
+      // an 'item' results row.
+      // If there is only the seeded ResultsRow, there were no attachments
+      // found.
+      if (attachments.size() == 1) {
+        attachments.get(0).setAttStatus(ResultsRow.NOATT);
+        ReportManager.getInstance().stdOutWriteln(attachments.get(0).toString());
+      } else {
+        boolean allGood = true;
+        final int rawTotal = attachments.size();
+        final int attTotal = rawTotal - 1; // See reason below.
+        // Start attCounter at 1 since the first element is always the
+        // item framework.
+        for (int attCounter = 1; attCounter < rawTotal; attCounter++) {
+          ResultsRow attRow = attachments.get(attCounter);
+          ReportManager.getInstance().getStats().incNumTotalAttachments();
+          logger.info(
+              "Processing item attachment [item#{}]-[att#{}] (out of [{}] attachments for this item)...",
+              itemCounter,
+              attCounter,
+              attTotal);
 
-					// Determine attachment status
-					if (attRow.getAttStatus().equals(ResultsRow.IGNORED)) {
-						// Consider not an error.
-						logger.info("Attachment {} is ignored.",
-								attRow.getAttFilePath());
-						ReportManager.getInstance().getStats()
-								.incNumTotalAttachmentsIgnored();
-					} else if (doesAttachmentExist(attRow)) {
-						logger.info("Attachment {} is present.",
-								attRow.getAttFilePath());
-						attRow.setAttStatus(ResultsRow.PRESENT);
-					} else {
-						logger.info("Attachment {} is missing.",
-								attRow.getAttFilePath());
-						ReportManager.getInstance().getStats()
-								.incNumTotalAttachmentsMissing();
-						attRow.setAttStatus(ResultsRow.MISSING);
-						ReportManager.getInstance().errOutWriteln(
-								attRow.toString());
-						allGood = false;
-					}
-					// Always send the attachment report to the standard file
-					// writer.
-					ReportManager.getInstance()
-							.stdOutWriteln(attRow.toString());
-				}
-				if (!allGood) {
-					ReportManager.getInstance().getStats()
-							.incNumTotalItemsAffected();
-				}
-			}
-		} catch (IOException e) {
-			// TODO - add to 'fatal errors' since returning false to stop the run
-			logger.fatal("Unrecoverable error while processing item - {}",
-					e.getMessage(), e);
-			return false;
-		}
-		return true;
-	}
+          // Determine attachment status
+          if (attRow.getAttStatus().equals(ResultsRow.IGNORED)) {
+            // Consider not an error.
+            logger.info("Attachment {} is ignored.", attRow.getAttFilePath());
+            ReportManager.getInstance().getStats().incNumTotalAttachmentsIgnored();
+          } else if (doesAttachmentExist(attRow)) {
+            logger.info("Attachment {} is present.", attRow.getAttFilePath());
+            attRow.setAttStatus(ResultsRow.PRESENT);
+          } else {
+            logger.info("Attachment {} is missing.", attRow.getAttFilePath());
+            ReportManager.getInstance().getStats().incNumTotalAttachmentsMissing();
+            attRow.setAttStatus(ResultsRow.MISSING);
+            ReportManager.getInstance().errOutWriteln(attRow.toString());
+            allGood = false;
+          }
+          // Always send the attachment report to the standard file
+          // writer.
+          ReportManager.getInstance().stdOutWriteln(attRow.toString());
+        }
+        if (!allGood) {
+          ReportManager.getInstance().getStats().incNumTotalItemsAffected();
+        }
+      }
+    } catch (IOException e) {
+      // TODO - add to 'fatal errors' since returning false to stop the run
+      logger.fatal("Unrecoverable error while processing item - {}", e.getMessage(), e);
+      return false;
+    }
+    return true;
+  }
 
-	private boolean doesAttachmentExist(ResultsRow attRow) {
-		int hash = attRow.getItemUuid().hashCode() & 127;
+  private boolean doesAttachmentExist(ResultsRow attRow) {
+    int hash = attRow.getItemUuid().hashCode() & 127;
 
-		String attPath = String.format("/%d/%s/%s/",
-						hash, attRow.getItemUuid(),
-						attRow.getItemVersion());
+    String attPath =
+        String.format("/%d/%s/%s/", hash, attRow.getItemUuid(), attRow.getItemVersion());
 
-		// Prevent odd encoding issues by not taking part in the format operation
-		// above.  Allow for a configured set of percent encoded values
-		String attName = attRow.getAttFilePath();
-		logger.debug("Original attachment name: [{}]", attName);
-		if(Config.getInstance().hasConfig(Config.CF_FILENAME_ENCODING_LIST)) {
-			for(String key : Config.getInstance().getConfigAsStringArray(Config.CF_FILENAME_ENCODING_LIST)) {
-				final String original = CheckFilesUtils.specialCharReplace(Config.get(Config.CF_FILENAME_ENCODING_BASE+key+Config.CF_FILENAME_ENCODING_ORIGINAL));
-				final String result = Config.get(Config.CF_FILENAME_ENCODING_BASE+key+Config.CF_FILENAME_ENCODING_RESULT);
-				logger.trace("Attachment replacement [{}]->[{}]", original, result);
-				attName = attName.replaceAll(original, result);
-				logger.trace("Attachment name after a replacement of [{}]->[{}]: [{}]", original, result, attName);
-			}
-		}
+    // Prevent odd encoding issues by not taking part in the format operation
+    // above.  Allow for a configured set of percent encoded values
+    String attName = attRow.getAttFilePath();
+    logger.debug("Original attachment name: [{}]", attName);
+    if (Config.getInstance().hasConfig(Config.CF_FILENAME_ENCODING_LIST)) {
+      for (String key :
+          Config.getInstance().getConfigAsStringArray(Config.CF_FILENAME_ENCODING_LIST)) {
+        final String original =
+            CheckFilesUtils.specialCharReplace(
+                Config.get(
+                    Config.CF_FILENAME_ENCODING_BASE + key + Config.CF_FILENAME_ENCODING_ORIGINAL));
+        final String result =
+            Config.get(Config.CF_FILENAME_ENCODING_BASE + key + Config.CF_FILENAME_ENCODING_RESULT);
+        logger.trace("Attachment replacement [{}]->[{}]", original, result);
+        attName = attName.replaceAll(original, result);
+        logger.trace(
+            "Attachment name after a replacement of [{}]->[{}]: [{}]", original, result, attName);
+      }
+    }
 
-		String basePath = Config.get(Config.CF_FILESTORE_DIR)+"/"+institutionsById.get(attRow.getInstitutionId())
-						.getFilestoreHandle()+"/Attachments";
+    String basePath =
+        Config.get(Config.CF_FILESTORE_DIR)
+            + "/"
+            + institutionsById.get(attRow.getInstitutionId()).getFilestoreHandle()
+            + "/Attachments";
 
-		// See if this attachment is in an 'advanced filestore'.
-		final String key = Config.CF_FILESTORE_DIR_ADV+attRow.getInstitutionId()+"."+attRow.getCollectionUuid();
-		logger.debug("Checking if the attachment [{}][{}] has an associated adv filestore via the property [{}].", attPath, attName, key);
-		if(Config.getInstance().hasConfig(key)) {
-			basePath = Config.get(key);
-		}
+    // See if this attachment is in an 'advanced filestore'.
+    final String key =
+        Config.CF_FILESTORE_DIR_ADV + attRow.getInstitutionId() + "." + attRow.getCollectionUuid();
+    logger.debug(
+        "Checking if the attachment [{}][{}] has an associated adv filestore via the property [{}].",
+        attPath,
+        attName,
+        key);
+    if (Config.getInstance().hasConfig(key)) {
+      basePath = Config.get(key);
+    }
 
-		final String path = basePath + attPath + attName;
-		final String altPath = basePath + "/" + attRow.getCollectionUuid() + attPath + attName;
+    final String path = basePath + attPath + attName;
+    final String altPath = basePath + "/" + attRow.getCollectionUuid() + attPath + attName;
 
-		if(Config.getInstance().hasConfig(key)) {
-			logger.info("Using advanced filestore path [{}] to check attachment.", path);
-		} else {
-			logger.info("Using path [{}] to check attachment.", path);
-		}
-		logger.info("Alt path [{}] to check attachment.", altPath);
+    if (Config.getInstance().hasConfig(key)) {
+      logger.info("Using advanced filestore path [{}] to check attachment.", path);
+    } else {
+      logger.info("Using path [{}] to check attachment.", path);
+    }
+    logger.info("Alt path [{}] to check attachment.", altPath);
 
-		if((new File(path)).exists()) {
-			return true;
-		} else {
-			return (new File(altPath)).exists();
-		}
-	}
+    if ((new File(path)).exists()) {
+      return true;
+    } else {
+      return (new File(altPath)).exists();
+    }
+  }
 
-	/**
-	 * if there is a filter.by.institution.shortname specified, confirm there's
-	 * a corresponding entry in the institution cache.
-	 * 
-	 * Sets a ReportManager fatal error if there isn't a corresponding entry.
-	 * 
-	 * @return
-	 */
-	private void confirmFilterByInstitution() {
-		String shortname = Config.get(Config.CF_FILTER_BY_INSTITUTION);
-		if (Check.isEmpty(shortname)) {
-			// non-existent / empty means check all institutions.
-			return;
-		}
+  /**
+   * if there is a filter.by.institution.shortname specified, confirm there's a corresponding entry
+   * in the institution cache.
+   *
+   * <p>Sets a ReportManager fatal error if there isn't a corresponding entry.
+   *
+   * @return
+   */
+  private void confirmFilterByInstitution() {
+    String shortname = Config.get(Config.CF_FILTER_BY_INSTITUTION);
+    if (Check.isEmpty(shortname)) {
+      // non-existent / empty means check all institutions.
+      return;
+    }
 
-		if (!institutionsByShortname.containsKey(shortname)) {
-			String msg = String
-					.format("The institution shortname to filter by [%s] is not in the institution cache.",
-							shortname);
-			logger.fatal(msg);
-			ReportManager.getInstance().addFatalError(msg);
-			return;
-		}
+    if (!institutionsByShortname.containsKey(shortname)) {
+      String msg =
+          String.format(
+              "The institution shortname to filter by [%s] is not in the institution cache.",
+              shortname);
+      logger.fatal(msg);
+      ReportManager.getInstance().addFatalError(msg);
+      return;
+    }
 
-		whereClauseExpressions.add(new WhereClauseExpression(
-				"institution_id = ?", institutionsByShortname.get(shortname)
-						.getId(), whereClauseExpressions.size() + 1));
-	}
+    whereClauseExpressions.add(
+        new WhereClauseExpression(
+            "institution_id = ?",
+            institutionsByShortname.get(shortname).getId(),
+            whereClauseExpressions.size() + 1));
+  }
 
-	/**
-	 * Using the institution cache, determine if all filestores are accounted
-	 * for.
-	 * 
-	 * Sets a ReportManager fatal error if there are any institutions without a
-	 * corresponding filestore.
-	 * 
-	 * @return
-	 */
-	private void confirmAllInstitutionFilestores() {
-		String filter = Config.get(Config.CF_FILTER_BY_INSTITUTION);
-		for (String shortname : institutionsByShortname.keySet()) {
-			// filter == null >> looking at all institutions
-			// filter == shortname >> only check that institution filestore
-			// handle
-			if ((Check.isEmpty(filter) || filter.equals(shortname))) {
-				InstitutionRow ir = institutionsByShortname.get(shortname);
-				ir.setFilestoreHandle(shortname);
-				File instFilestore = new File(Config.get(Config.CF_FILESTORE_DIR), ir.getFilestoreHandle());
-				if (!instFilestore.exists()) {
-					logger.info(
-							"Institution filestore [{}] does not exist.  Checking for an alias...",
-							instFilestore.getAbsolutePath());
-					// Might have changed the filestore handle. The config
-					// should
-					// specify.
-					String handle = Config.getInstance().getFilestoreHandle(
-							shortname);
-					if (handle == null || handle.isEmpty()) {
-						// Nothing specified. Fail.
-						String msg = String
-								.format("Institution [%s] filestore handle is different than shortname, "
-										+ "but is not specified in the properties.",
-										shortname);
-						ReportManager.getInstance().addFatalError(msg);
-						logger.error(msg);
-						return;
-					}
-					ir.setFilestoreHandle(handle);
-					instFilestore = new File(Config.get(Config.CF_FILESTORE_DIR), ir.getFilestoreHandle());
-					if (!instFilestore.exists()) {
-						// Bad handle. Fail.
-						String msg = String
-								.format("Institution [%s] filestore handle is different than shortname, "
-										+ "but the handle (directory) specified in the properties [%s] does not exist.",
-										shortname, handle);
-						ReportManager.getInstance().addFatalError(msg);
-						logger.error(msg);
-						return;
-					}
-				}
+  /**
+   * Using the institution cache, determine if all filestores are accounted for.
+   *
+   * <p>Sets a ReportManager fatal error if there are any institutions without a corresponding
+   * filestore.
+   *
+   * @return
+   */
+  private void confirmAllInstitutionFilestores() {
+    String filter = Config.get(Config.CF_FILTER_BY_INSTITUTION);
+    for (String shortname : institutionsByShortname.keySet()) {
+      // filter == null >> looking at all institutions
+      // filter == shortname >> only check that institution filestore
+      // handle
+      if ((Check.isEmpty(filter) || filter.equals(shortname))) {
+        InstitutionRow ir = institutionsByShortname.get(shortname);
+        ir.setFilestoreHandle(shortname);
+        File instFilestore = new File(Config.get(Config.CF_FILESTORE_DIR), ir.getFilestoreHandle());
+        if (!instFilestore.exists()) {
+          logger.info(
+              "Institution filestore [{}] does not exist.  Checking for an alias...",
+              instFilestore.getAbsolutePath());
+          // Might have changed the filestore handle. The config
+          // should
+          // specify.
+          String handle = Config.getInstance().getFilestoreHandle(shortname);
+          if (handle == null || handle.isEmpty()) {
+            // Nothing specified. Fail.
+            String msg =
+                String.format(
+                    "Institution [%s] filestore handle is different than shortname, "
+                        + "but is not specified in the properties.",
+                    shortname);
+            ReportManager.getInstance().addFatalError(msg);
+            logger.error(msg);
+            return;
+          }
+          ir.setFilestoreHandle(handle);
+          instFilestore = new File(Config.get(Config.CF_FILESTORE_DIR), ir.getFilestoreHandle());
+          if (!instFilestore.exists()) {
+            // Bad handle. Fail.
+            String msg =
+                String.format(
+                    "Institution [%s] filestore handle is different than shortname, "
+                        + "but the handle (directory) specified in the properties [%s] does not exist.",
+                    shortname, handle);
+            ReportManager.getInstance().addFatalError(msg);
+            logger.error(msg);
+            return;
+          }
+        }
 
-				// Check that the Attachments directory exists
-				File attsHandle = new File(instFilestore, "Attachments");
-				if (!attsHandle.exists()) {
-					// Bad handle. Fail.
-					String msg = String
-							.format("Institution [%s] filestore attachments directory [%s] does not exist.",
-									shortname, attsHandle.getAbsolutePath());
-					ReportManager.getInstance().addFatalError(msg);
-					logger.error(msg);
-					return;
-				}
+        // Check that the Attachments directory exists
+        File attsHandle = new File(instFilestore, "Attachments");
+        if (!attsHandle.exists()) {
+          // Bad handle. Fail.
+          String msg =
+              String.format(
+                  "Institution [%s] filestore attachments directory [%s] does not exist.",
+                  shortname, attsHandle.getAbsolutePath());
+          ReportManager.getInstance().addFatalError(msg);
+          logger.error(msg);
+          return;
+        }
 
-				if (!attsHandle.isDirectory()) {
-					// Bad handle. Fail.
-					String msg = String
-							.format("Institution [{}] filestore attachments directory [{}] is not a directory.",
-									shortname, attsHandle.getAbsolutePath());
-					ReportManager.getInstance().addFatalError(msg);
-					logger.error(msg);
-					return;
-				}
-			}
-		}
-	}
+        if (!attsHandle.isDirectory()) {
+          // Bad handle. Fail.
+          String msg =
+              String.format(
+                  "Institution [{}] filestore attachments directory [{}] is not a directory.",
+                  shortname,
+                  attsHandle.getAbsolutePath());
+          ReportManager.getInstance().addFatalError(msg);
+          logger.error(msg);
+          return;
+        }
+      }
+    }
+  }
 
-	private void setupDbConnection(
-			String dbUrl, String un, String pw) {
-		try {
-			Class.forName("org.postgresql.Driver");
-			String connectionUrl = String.format(
-					"%s?user=%s&password=%s",
-					dbUrl, un, pw);
-			con = DriverManager.getConnection(connectionUrl);
-			logger.info(String.format("Connected to %s",
-					dbUrl));
-			con.setAutoCommit(false);
-			// Check the connection works.
-			String SQL = "SELECT id, uuid FROM item limit 1";
-			Statement stmt = con.createStatement();
-			long start = System.currentTimeMillis();
-			ResultSet rs = stmt.executeQuery(SQL);
-			boolean hasResults = rs.next();
-			rs.close();
-			long dur = System.currentTimeMillis() - start;
-			if (hasResults) {
-				logger.info("Confirmed DB connection in 0 ms.");
-				ReportManager.getInstance().getStats().queryRan(dur);
-				return;
-			} else {
-				String msg = String.format(
-						"Unable to confirm connection to the DB [%s] with username [%s] and a password of length [%d]",
-						Config.get(Config.CF_DB_URL), Config.get(Config.CF_DB_USERNAME), Config.get(Config.CF_DB_PASSWORD).length());
-				logger.fatal(msg);
-				ReportManager.getInstance().addFatalError(msg);
-				return;
-			}
-		} catch (Exception e) {
-			String msg = String.format(
-					"Unable to connect to the DB [%s] with username [%s] and a password of length [%d]",
-							Config.get(Config.CF_DB_URL), Config.get(Config.CF_DB_USERNAME), Config.get(Config.CF_DB_PASSWORD).length());
-			logger.fatal(msg, e);
-			ReportManager.getInstance().addFatalError(msg);
-			return;
-		}
-	}
+  private void setupDbConnection(String dbUrl, String un, String pw) {
+    try {
+      Class.forName("org.postgresql.Driver");
+      String connectionUrl = String.format("%s?user=%s&password=%s", dbUrl, un, pw);
+      con = DriverManager.getConnection(connectionUrl);
+      logger.info(String.format("Connected to %s", dbUrl));
+      con.setAutoCommit(false);
+      // Check the connection works.
+      String SQL = "SELECT id, uuid FROM item limit 1";
+      Statement stmt = con.createStatement();
+      long start = System.currentTimeMillis();
+      ResultSet rs = stmt.executeQuery(SQL);
+      boolean hasResults = rs.next();
+      rs.close();
+      long dur = System.currentTimeMillis() - start;
+      if (hasResults) {
+        logger.info("Confirmed DB connection in 0 ms.");
+        ReportManager.getInstance().getStats().queryRan(dur);
+        return;
+      } else {
+        String msg =
+            String.format(
+                "Unable to confirm connection to the DB [%s] with username [%s] and a password of length [%d]",
+                Config.get(Config.CF_DB_URL),
+                Config.get(Config.CF_DB_USERNAME),
+                Config.get(Config.CF_DB_PASSWORD).length());
+        logger.fatal(msg);
+        ReportManager.getInstance().addFatalError(msg);
+        return;
+      }
+    } catch (Exception e) {
+      String msg =
+          String.format(
+              "Unable to connect to the DB [%s] with username [%s] and a password of length [%d]",
+              Config.get(Config.CF_DB_URL),
+              Config.get(Config.CF_DB_USERNAME),
+              Config.get(Config.CF_DB_PASSWORD).length());
+      logger.fatal(msg, e);
+      ReportManager.getInstance().addFatalError(msg);
+      return;
+    }
+  }
 
-	private boolean cacheAttachmentsPerItem() {
-		long start = System.currentTimeMillis();
-		int counter = 0;
-		try {
-			// For each item cached, query for the associated attachments.
-			for (List<ResultsRow> itemRowSet : attachmentsCache.values()) {
-				Pair<Boolean, Integer> result = cacheAttachmentsPerItem(itemRowSet.get(0).getItemId());
-				if(!result.getFirst()) {
-					return false;
-				}
-				counter += result.getSecond();
-			}
-		} catch (Exception e) {
-			logger.error("Unable to cache attachments (query per item) - {}",
-							e.getMessage(), e);
-			return false;
-		}
-		long dur = System.currentTimeMillis() - start;
-		logger.info("Cached {} attachments (query per item).  Duration {} ms.",
-						counter, dur);
-		ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
-		return true;
-	}
+  private boolean cacheAttachmentsPerItem() {
+    long start = System.currentTimeMillis();
+    int counter = 0;
+    try {
+      // For each item cached, query for the associated attachments.
+      for (List<ResultsRow> itemRowSet : attachmentsCache.values()) {
+        Pair<Boolean, Integer> result = cacheAttachmentsPerItem(itemRowSet.get(0).getItemId());
+        if (!result.getFirst()) {
+          return false;
+        }
+        counter += result.getSecond();
+      }
+    } catch (Exception e) {
+      logger.error("Unable to cache attachments (query per item) - {}", e.getMessage(), e);
+      return false;
+    }
+    long dur = System.currentTimeMillis() - start;
+    logger.info("Cached {} attachments (query per item).  Duration {} ms.", counter, dur);
+    ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
+    return true;
+  }
 
-	private Pair<Boolean, Integer> cacheAttachmentsPerItem(int itemId) {
-		long start = System.currentTimeMillis();
-		int counter = 0;
-		try {
-			long batchStart = System.currentTimeMillis();
+  private Pair<Boolean, Integer> cacheAttachmentsPerItem(int itemId) {
+    long start = System.currentTimeMillis();
+    int counter = 0;
+    try {
+      long batchStart = System.currentTimeMillis();
 
-			PreparedStatement stmt = con
-					.prepareStatement("select a.type, a.url, a.value1, a.uuid, a.id "
-							+ "from attachment a where a.item_id = ?");
-			stmt.setInt(1, itemId);
-			ResultSet rs = stmt.executeQuery();
-			while (rs.next()) {
-				counter++;
-				ResultsRow attRow = inflateAttRow(rs.getString(1),
-						rs.getString(2), rs.getString(3), rs.getString(4),
-						rs.getInt(5), itemId);
-				// Note - at this point, attRow will not be null.
-				attachmentsCache.get(attRow.getItemId()).add(attRow);
-				logger.info("Attachment ({}) gathered: {}", counter,
-						attRow.toString());
-			}
-			rs.close();
-			long batchDur = System.currentTimeMillis() - batchStart;
-			ReportManager.getInstance().getStats().queryRan(batchDur);
-			logger.debug("Cached a batch of attachments.  Duration {} ms.",
-					batchDur);
-		} catch (Exception e) {
-			logger.error("Unable to cache attachments (query per item) - {}",
-					e.getMessage(), e);
-			return Pair.pair(false, counter);
-		}
-		long dur = System.currentTimeMillis() - start;
-		logger.info("Cached {} attachments (query per item).  Duration {} ms.",
-				counter, dur);
-		ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
-		return Pair.pair(true, counter);
-	}
+      PreparedStatement stmt =
+          con.prepareStatement(
+              "select a.type, a.url, a.value1, a.uuid, a.id "
+                  + "from attachment a where a.item_id = ?");
+      stmt.setInt(1, itemId);
+      ResultSet rs = stmt.executeQuery();
+      while (rs.next()) {
+        counter++;
+        ResultsRow attRow =
+            inflateAttRow(
+                rs.getString(1),
+                rs.getString(2),
+                rs.getString(3),
+                rs.getString(4),
+                rs.getInt(5),
+                itemId);
+        // Note - at this point, attRow will not be null.
+        attachmentsCache.get(attRow.getItemId()).add(attRow);
+        logger.info("Attachment ({}) gathered: {}", counter, attRow.toString());
+      }
+      rs.close();
+      long batchDur = System.currentTimeMillis() - batchStart;
+      ReportManager.getInstance().getStats().queryRan(batchDur);
+      logger.debug("Cached a batch of attachments.  Duration {} ms.", batchDur);
+    } catch (Exception e) {
+      logger.error("Unable to cache attachments (query per item) - {}", e.getMessage(), e);
+      return Pair.pair(false, counter);
+    }
+    long dur = System.currentTimeMillis() - start;
+    logger.info("Cached {} attachments (query per item).  Duration {} ms.", counter, dur);
+    ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
+    return Pair.pair(true, counter);
+  }
 
-	private boolean cacheAttachmentsAll() {
-		long start = System.currentTimeMillis();
-		int counter = 0;
-		try {
-			PreparedStatement stmt = con
-					.prepareStatement("select a.type, a.url, a.value1, a.uuid, a.id, a.item_id "
-							+ "from attachment a");
-			ResultSet rs = stmt.executeQuery();
-			// For each attachment, access the appropriate item attachment list
-			// and add the attachment
-			while (rs.next()) {
-				counter++;
-				ResultsRow attRow = inflateAttRow(rs.getString(1),
-						rs.getString(2), rs.getString(3), rs.getString(4),
-						rs.getInt(5), rs.getInt(6));
-				if (attRow != null) {
-					attachmentsCache.get(attRow.getItemId()).add(attRow);
-					logger.info("Attachment ({}) gathered: {}", counter,
-							attRow.toString());
-				}
-			}
-			rs.close();
-		} catch (Exception e) {
-			logger.error("Unable to cache attachments (single query) - {}",
-					e.getMessage(), e);
-			return false;
-		}
-		long dur = System.currentTimeMillis() - start;
-		ReportManager.getInstance().getStats().queryRan(dur);
-		logger.info("Cached {} attachments (single query).  Duration {} ms.",
-				counter, dur);
-		ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
-		return true;
-	}
+  private boolean cacheAttachmentsAll() {
+    long start = System.currentTimeMillis();
+    int counter = 0;
+    try {
+      PreparedStatement stmt =
+          con.prepareStatement(
+              "select a.type, a.url, a.value1, a.uuid, a.id, a.item_id " + "from attachment a");
+      ResultSet rs = stmt.executeQuery();
+      // For each attachment, access the appropriate item attachment list
+      // and add the attachment
+      while (rs.next()) {
+        counter++;
+        ResultsRow attRow =
+            inflateAttRow(
+                rs.getString(1),
+                rs.getString(2),
+                rs.getString(3),
+                rs.getString(4),
+                rs.getInt(5),
+                rs.getInt(6));
+        if (attRow != null) {
+          attachmentsCache.get(attRow.getItemId()).add(attRow);
+          logger.info("Attachment ({}) gathered: {}", counter, attRow.toString());
+        }
+      }
+      rs.close();
+    } catch (Exception e) {
+      logger.error("Unable to cache attachments (single query) - {}", e.getMessage(), e);
+      return false;
+    }
+    long dur = System.currentTimeMillis() - start;
+    ReportManager.getInstance().getStats().queryRan(dur);
+    logger.info("Cached {} attachments (single query).  Duration {} ms.", counter, dur);
+    ReportManager.getInstance().getStats().incNumGrandTotalAttachments(counter);
+    return true;
+  }
 
-	private ResultsRow inflateAttRow(String attType, String attUrl,
-			String value1, String attUuid, int attId, int itemId) {
-		// If an attachment was found without the parent item, log a
-		// warning, but effectively ignore.
-		if (!attachmentsCache.containsKey(itemId)) {
-			logger.warn(
-					"Found an attachment whose itemId DOES NOT EXIST in the item cache.  "
-							+ "Ignoring (not caching): type=[{}], url=[{}], value1=[{}], uuid=[{}], attId=[{}], itemId=[{}]",
-					attType, attUrl, value1, attUuid, attId, itemId);
-			return null;
-		}
+  private ResultsRow inflateAttRow(
+      String attType, String attUrl, String value1, String attUuid, int attId, int itemId) {
+    // If an attachment was found without the parent item, log a
+    // warning, but effectively ignore.
+    if (!attachmentsCache.containsKey(itemId)) {
+      logger.warn(
+          "Found an attachment whose itemId DOES NOT EXIST in the item cache.  "
+              + "Ignoring (not caching): type=[{}], url=[{}], value1=[{}], uuid=[{}], attId=[{}], itemId=[{}]",
+          attType,
+          attUrl,
+          value1,
+          attUuid,
+          attId,
+          itemId);
+      return null;
+    }
 
-		// Build out the general attributes
-		ResultsRow attRow = ResultsRow.buildItemFrame(attachmentsCache.get(
-				itemId).get(0));
+    // Build out the general attributes
+    ResultsRow attRow = ResultsRow.buildItemFrame(attachmentsCache.get(itemId).get(0));
 
-		// inflate the static metadata
-		attRow.setAttId(attId);
-		attRow.setAttUuid(attUuid);
-		attRow.setAttUrl(attUrl);
-		attRow.setAttType(attType);
+    // inflate the static metadata
+    attRow.setAttId(attId);
+    attRow.setAttUuid(attUuid);
+    attRow.setAttUrl(attUrl);
+    attRow.setAttType(attType);
 
-		// Determine the filestore
-		if (attRow.getAttType().equals("file")) {
-			attRow.setAttFilePath(attRow.getAttUrl());
-		} else if (attRow.getAttType().equals("zip")) {
-			attRow.setAttFilePath(attRow.getAttUrl());
-		} else if (attRow.getAttType().equals("html")) {
-			attRow.setAttFilePath(String.format("_mypages/%s/page.html",
-					attRow.getAttUuid()));
-		} else if (attRow.getAttType().equals("custom")
-				&& value1.equals("scorm")) {
-			attRow.setAttType("scorm");
-			// Unsupported for now.
-			// filepath = String.format("_IMS/%s", attRow.getAttUrl());
-			attRow.setAttStatus(ResultsRow.IGNORED);
-		} else {
-			// Ignore all other attachments (URLs, Flickr, Equella resources,
-			// etc)
-			attRow.setAttStatus(ResultsRow.IGNORED);
-		}
+    // Determine the filestore
+    if (attRow.getAttType().equals("file")) {
+      attRow.setAttFilePath(attRow.getAttUrl());
+    } else if (attRow.getAttType().equals("zip")) {
+      attRow.setAttFilePath(attRow.getAttUrl());
+    } else if (attRow.getAttType().equals("html")) {
+      attRow.setAttFilePath(String.format("_mypages/%s/page.html", attRow.getAttUuid()));
+    } else if (attRow.getAttType().equals("custom") && value1.equals("scorm")) {
+      attRow.setAttType("scorm");
+      // Unsupported for now.
+      // filepath = String.format("_IMS/%s", attRow.getAttUrl());
+      attRow.setAttStatus(ResultsRow.IGNORED);
+    } else {
+      // Ignore all other attachments (URLs, Flickr, Equella resources,
+      // etc)
+      attRow.setAttStatus(ResultsRow.IGNORED);
+    }
 
-		return attRow;
-	}
+    return attRow;
+  }
 
-	private void cacheCollections() {
-		long start = System.currentTimeMillis();
-		try {
-			PreparedStatement stmt = con
-					.prepareStatement("select c.id, e.uuid, e.institution_id "
-							+ "from item_definition c "
-							+ "inner join base_entity e on c.id = e.id");
-			ResultSet rs = stmt.executeQuery();
-			while (rs.next()) {
-				CollectionRow cr = new CollectionRow();
-				cr.setId(rs.getInt(1));
-				cr.setInstitutionId(rs.getInt(3));
-				cr.setUuid(rs.getString(2));
+  private void cacheCollections() {
+    long start = System.currentTimeMillis();
+    try {
+      PreparedStatement stmt =
+          con.prepareStatement(
+              "select c.id, e.uuid, e.institution_id "
+                  + "from item_definition c "
+                  + "inner join base_entity e on c.id = e.id");
+      ResultSet rs = stmt.executeQuery();
+      while (rs.next()) {
+        CollectionRow cr = new CollectionRow();
+        cr.setId(rs.getInt(1));
+        cr.setInstitutionId(rs.getInt(3));
+        cr.setUuid(rs.getString(2));
 
-				collectionsById.put(cr.getId(), cr);
-				// collectionsByUuid.put(rs.getString(2), rs.getInt(1));
-				logger.info("Cached collection:  {}", cr.toString());
-			}
-			rs.close();
-		} catch (Exception e) {
-			String msg = String.format("Unable to cache collections - %s",
-					e.getMessage());
-			logger.fatal(msg, e);
-			ReportManager.getInstance().addFatalError(msg);
-			return;
-		}
-		long dur = System.currentTimeMillis() - start;
-		ReportManager.getInstance().getStats().queryRan(dur);
-		logger.info("Cached collections.  Duration {} ms.", dur);
-		return;
-	}
+        collectionsById.put(cr.getId(), cr);
+        // collectionsByUuid.put(rs.getString(2), rs.getInt(1));
+        logger.info("Cached collection:  {}", cr.toString());
+      }
+      rs.close();
+    } catch (Exception e) {
+      String msg = String.format("Unable to cache collections - %s", e.getMessage());
+      logger.fatal(msg, e);
+      ReportManager.getInstance().addFatalError(msg);
+      return;
+    }
+    long dur = System.currentTimeMillis() - start;
+    ReportManager.getInstance().getStats().queryRan(dur);
+    logger.info("Cached collections.  Duration {} ms.", dur);
+    return;
+  }
 
-	private void cacheInstitutions() {
-		long start = System.currentTimeMillis();
-		try {
-			PreparedStatement stmt = con
-					.prepareStatement("select i.id, i.short_name, i.name, i.unique_id, i.url "
-							+ "from institution i order by i.short_name");
-			ResultSet rs = stmt.executeQuery();
-			while (rs.next()) {
-				InstitutionRow ir = new InstitutionRow();
-				ir.setId(rs.getInt(1));
-				ir.setShortname(rs.getString(2));
-				ir.setName(rs.getString(3));
-				ir.setUniqueId(rs.getString(4));
-				ir.setUrl(rs.getString(5));
-				institutionsByShortname.put(ir.getShortname(), ir);
-				institutionsById.put(ir.getId(), ir);
-				logger.info("Cached institution: {}", ir.toString());
-			}
-			rs.close();
-		} catch (Exception e) {
-			String msg = String.format("Unable to cache institutions - %s",
-					e.getMessage());
-			logger.fatal(msg, e);
-			ReportManager.getInstance().addFatalError(msg);
-			return;
-		}
-		long dur = System.currentTimeMillis() - start;
-		ReportManager.getInstance().getStats().queryRan(dur);
-		logger.info("Cached institutions.  Duration {} ms.", dur);
-		return;
-	}
+  private void cacheInstitutions() {
+    long start = System.currentTimeMillis();
+    try {
+      PreparedStatement stmt =
+          con.prepareStatement(
+              "select i.id, i.short_name, i.name, i.unique_id, i.url "
+                  + "from institution i order by i.short_name");
+      ResultSet rs = stmt.executeQuery();
+      while (rs.next()) {
+        InstitutionRow ir = new InstitutionRow();
+        ir.setId(rs.getInt(1));
+        ir.setShortname(rs.getString(2));
+        ir.setName(rs.getString(3));
+        ir.setUniqueId(rs.getString(4));
+        ir.setUrl(rs.getString(5));
+        institutionsByShortname.put(ir.getShortname(), ir);
+        institutionsById.put(ir.getId(), ir);
+        logger.info("Cached institution: {}", ir.toString());
+      }
+      rs.close();
+    } catch (Exception e) {
+      String msg = String.format("Unable to cache institutions - %s", e.getMessage());
+      logger.fatal(msg, e);
+      ReportManager.getInstance().addFatalError(msg);
+      return;
+    }
+    long dur = System.currentTimeMillis() - start;
+    ReportManager.getInstance().getStats().queryRan(dur);
+    logger.info("Cached institutions.  Duration {} ms.", dur);
+    return;
+  }
 
-	private void confirmFilterByCollection() {
-		if (Check.isEmpty(Config.get(Config.CF_FILTER_BY_COLLECTION))) {
-			logger.info("Filter by collection ID not specified.  Not filtering by collection");
-			return;
-		}
+  private void confirmFilterByCollection() {
+    if (Check.isEmpty(Config.get(Config.CF_FILTER_BY_COLLECTION))) {
+      logger.info("Filter by collection ID not specified.  Not filtering by collection");
+      return;
+    }
 
-		final int id = Config.getInstance().getConfigAsInt(Config.CF_FILTER_BY_COLLECTION);
-		if (!collectionsById.containsKey(id)) {
-			String msg = String
-					.format("Unable to find the collection ID [%s].  Not a valid filter.",
-							Config.get(Config.CF_FILTER_BY_COLLECTION));
-			logger.fatal(msg);
-			ReportManager.getInstance().addFatalError(msg);
-			return;
-		}
+    final int id = Config.getInstance().getConfigAsInt(Config.CF_FILTER_BY_COLLECTION);
+    if (!collectionsById.containsKey(id)) {
+      String msg =
+          String.format(
+              "Unable to find the collection ID [%s].  Not a valid filter.",
+              Config.get(Config.CF_FILTER_BY_COLLECTION));
+      logger.fatal(msg);
+      ReportManager.getInstance().addFatalError(msg);
+      return;
+    }
 
-		whereClauseExpressions.add(new WhereClauseExpression(
-				"item_definition_id = ?", id, whereClauseExpressions
-						.size() + 1));
-	}
+    whereClauseExpressions.add(
+        new WhereClauseExpression("item_definition_id = ?", id, whereClauseExpressions.size() + 1));
+  }
 
-	private boolean cacheItemsAll() {
-		long start = System.currentTimeMillis();
-		try {
-			PreparedStatement stmt = con
-					.prepareStatement(String
-							.format("select id, uuid, version, status, item_definition_id, institution_id from item %s order by id",
-									WhereClauseExpression
-											.makeWhereClause(whereClauseExpressions)));
-			WhereClauseExpression.setParms(stmt, whereClauseExpressions);
+  private boolean cacheItemsAll() {
+    long start = System.currentTimeMillis();
+    try {
+      PreparedStatement stmt =
+          con.prepareStatement(
+              String.format(
+                  "select id, uuid, version, status, item_definition_id, institution_id from item %s order by id",
+                  WhereClauseExpression.makeWhereClause(whereClauseExpressions)));
+      WhereClauseExpression.setParms(stmt, whereClauseExpressions);
 
-			ResultSet rs = stmt.executeQuery();
-			while (rs.next()) {
-				ResultsRow itemRow = new ResultsRow();
-				itemRow.setItemId(rs.getInt(1));
-				itemRow.setItemUuid(rs.getString(2));
-				itemRow.setItemVersion("" + rs.getInt(3));
-				itemRow.setItemStatus(rs.getString(4));
-				int collId = rs.getInt(5);
-				if (collectionsById.containsKey(collId)) {
-					itemRow.setCollectionUuid(collectionsById.get(collId)
-							.getUuid());
-				} else {
-					logger.warn(
-							"Expected collection ID [{}] not cached for item {}/{}.",
-							collId, itemRow.getItemUuid(),
-							itemRow.getItemVersion());
-					itemRow.setCollectionUuid("" + collId);
-				}
-				itemRow.setInstitutionId(rs.getInt(6));
-				itemRow.setInstitutionShortname(institutionsById.get(
-						itemRow.getInstitutionId()).getShortname());
-				List<ResultsRow> seeder = new ArrayList<ResultsRow>();
-				seeder.add(itemRow);
-				attachmentsCache.put(itemRow.getItemId(), seeder);
+      ResultSet rs = stmt.executeQuery();
+      while (rs.next()) {
+        ResultsRow itemRow = new ResultsRow();
+        itemRow.setItemId(rs.getInt(1));
+        itemRow.setItemUuid(rs.getString(2));
+        itemRow.setItemVersion("" + rs.getInt(3));
+        itemRow.setItemStatus(rs.getString(4));
+        int collId = rs.getInt(5);
+        if (collectionsById.containsKey(collId)) {
+          itemRow.setCollectionUuid(collectionsById.get(collId).getUuid());
+        } else {
+          logger.warn(
+              "Expected collection ID [{}] not cached for item {}/{}.",
+              collId,
+              itemRow.getItemUuid(),
+              itemRow.getItemVersion());
+          itemRow.setCollectionUuid("" + collId);
+        }
+        itemRow.setInstitutionId(rs.getInt(6));
+        itemRow.setInstitutionShortname(
+            institutionsById.get(itemRow.getInstitutionId()).getShortname());
+        List<ResultsRow> seeder = new ArrayList<ResultsRow>();
+        seeder.add(itemRow);
+        attachmentsCache.put(itemRow.getItemId(), seeder);
 
-				logger.info("Found [{}] item:  {}", (attachmentsCache.size()),
-						itemRow.toString());
-			}
-			rs.close();
-		} catch (Exception e) {
-			logger.error("Unable to cache items (single query) - {}",
-					e.getMessage(), e);
-			return false;
-		}
-		long dur = System.currentTimeMillis() - start;
-		ReportManager.getInstance().getStats().queryRan(dur);
-		logger.info("Cached items (single query).  Duration {} ms.", dur);
-		ReportManager.getInstance().getStats().incNumGrandTotalItems(attachmentsCache.size());
-		return true;
-	}
+        logger.info("Found [{}] item:  {}", (attachmentsCache.size()), itemRow.toString());
+      }
+      rs.close();
+    } catch (Exception e) {
+      logger.error("Unable to cache items (single query) - {}", e.getMessage(), e);
+      return false;
+    }
+    long dur = System.currentTimeMillis() - start;
+    ReportManager.getInstance().getStats().queryRan(dur);
+    logger.info("Cached items (single query).  Duration {} ms.", dur);
+    ReportManager.getInstance().getStats().incNumGrandTotalItems(attachmentsCache.size());
+    return true;
+  }
 
-	/**
-	 * Fails in SQL Server 2008. Works in SQL Server 2012.
-	 * 
-	 * @return
-	 */
-	private boolean cacheItemsBatched(boolean confirmInline) {
-		long start = System.currentTimeMillis();
-		try {
-			String sql = String
-					.format("select id, uuid, version, status, item_definition_id, institution_id from item %s order by id OFFSET ? ROWS FETCH NEXT ? ROWS ONLY",
-							WhereClauseExpression
-									.makeWhereClause(whereClauseExpressions));
-			logger.debug("SQL:  [{}]", sql);
-			int offsetCounter = 0;
-			boolean hasMore = false;
-			do {
-				// Assume no rows are returned.
-				hasMore = false;
-				long batchStart = System.currentTimeMillis();
+  /**
+   * Fails in SQL Server 2008. Works in SQL Server 2012.
+   *
+   * @return
+   */
+  private boolean cacheItemsBatched(boolean confirmInline) {
+    long start = System.currentTimeMillis();
+    try {
+      String sql =
+          String.format(
+              "select id, uuid, version, status, item_definition_id, institution_id from item %s order by id OFFSET ? ROWS FETCH NEXT ? ROWS ONLY",
+              WhereClauseExpression.makeWhereClause(whereClauseExpressions));
+      logger.debug("SQL:  [{}]", sql);
+      int offsetCounter = 0;
+      boolean hasMore = false;
+      do {
+        // Assume no rows are returned.
+        hasMore = false;
+        long batchStart = System.currentTimeMillis();
 
-				PreparedStatement stmt = con.prepareStatement(sql);
-				WhereClauseExpression.setParms(stmt, whereClauseExpressions);
-				stmt.setInt(whereClauseExpressions.size() + 1, offsetCounter
-						* Config.getInstance().getConfigAsInt(Config.CF_NUM_OF_ITEMS_PER_QUERY));
-				stmt.setInt(whereClauseExpressions.size() + 2, Config.getInstance().getConfigAsInt(Config.CF_NUM_OF_ITEMS_PER_QUERY));
-				ResultSet rs = stmt.executeQuery();
-				while (rs.next()) {
-					hasMore = true;
-					ResultsRow itemRow = new ResultsRow();
-					itemRow.setItemId(rs.getInt(1));
-					itemRow.setItemUuid(rs.getString(2));
-					itemRow.setItemVersion("" + rs.getInt(3));
-					itemRow.setItemStatus(rs.getString(4));
-					int collId = rs.getInt(5);
-					if (collectionsById.containsKey(collId)) {
-						itemRow.setCollectionUuid(collectionsById.get(collId)
-								.getUuid());
-					} else {
-						logger.warn(
-								"Expected collection ID [{}] not cached for item {}/{}.",
-								collId, itemRow.getItemUuid(),
-								itemRow.getItemVersion());
-						itemRow.setCollectionUuid("" + collId);
-					}
-					itemRow.setInstitutionId(rs.getInt(6));
-					itemRow.setInstitutionShortname(institutionsById.get(
-							itemRow.getInstitutionId()).getShortname());
+        PreparedStatement stmt = con.prepareStatement(sql);
+        WhereClauseExpression.setParms(stmt, whereClauseExpressions);
+        stmt.setInt(
+            whereClauseExpressions.size() + 1,
+            offsetCounter * Config.getInstance().getConfigAsInt(Config.CF_NUM_OF_ITEMS_PER_QUERY));
+        stmt.setInt(
+            whereClauseExpressions.size() + 2,
+            Config.getInstance().getConfigAsInt(Config.CF_NUM_OF_ITEMS_PER_QUERY));
+        ResultSet rs = stmt.executeQuery();
+        while (rs.next()) {
+          hasMore = true;
+          ResultsRow itemRow = new ResultsRow();
+          itemRow.setItemId(rs.getInt(1));
+          itemRow.setItemUuid(rs.getString(2));
+          itemRow.setItemVersion("" + rs.getInt(3));
+          itemRow.setItemStatus(rs.getString(4));
+          int collId = rs.getInt(5);
+          if (collectionsById.containsKey(collId)) {
+            itemRow.setCollectionUuid(collectionsById.get(collId).getUuid());
+          } else {
+            logger.warn(
+                "Expected collection ID [{}] not cached for item {}/{}.",
+                collId,
+                itemRow.getItemUuid(),
+                itemRow.getItemVersion());
+            itemRow.setCollectionUuid("" + collId);
+          }
+          itemRow.setInstitutionId(rs.getInt(6));
+          itemRow.setInstitutionShortname(
+              institutionsById.get(itemRow.getInstitutionId()).getShortname());
 
-					List<ResultsRow> seeder = new ArrayList<ResultsRow>();
-					seeder.add(itemRow);
-					attachmentsCache.put(itemRow.getItemId(), seeder);
+          List<ResultsRow> seeder = new ArrayList<ResultsRow>();
+          seeder.add(itemRow);
+          attachmentsCache.put(itemRow.getItemId(), seeder);
 
-					logger.info("Found the [{}]th item:  {}",
-							(attachmentsCache.size()), itemRow.toString());
-					if(confirmInline) {
-						Pair<Boolean, Integer> result = cacheAttachmentsPerItem(itemRow.getItemId());
-						if(result.getFirst()) {
-							if(!processItem(itemRow.getItemId(), attachmentsCache.size())) {
-								rs.close();
-								throw new Exception("Unable to check attachments for item [" + itemRow.getItemId() + "]");
-							}
-						} else {
-							rs.close();
-							throw new Exception("Unable to cache attachments for item [" + itemRow.getItemId() + "]");
-						}
-					}
-				}
-				rs.close();
-				offsetCounter++;
-				long batchDur = System.currentTimeMillis() - batchStart;
-				ReportManager.getInstance().getStats().queryRan(batchDur);
-				if (hasMore) {
-					logger.info("Cached a batch of items.  Duration {} ms.",
-							batchDur);
-				} else {
-					logger.info(
-							"No more batches of items found to cache.  Duration {} ms.",
-							batchDur);
-				}
+          logger.info("Found the [{}]th item:  {}", (attachmentsCache.size()), itemRow.toString());
+          if (confirmInline) {
+            Pair<Boolean, Integer> result = cacheAttachmentsPerItem(itemRow.getItemId());
+            if (result.getFirst()) {
+              if (!processItem(itemRow.getItemId(), attachmentsCache.size())) {
+                rs.close();
+                throw new Exception(
+                    "Unable to check attachments for item [" + itemRow.getItemId() + "]");
+              }
+            } else {
+              rs.close();
+              throw new Exception(
+                  "Unable to cache attachments for item [" + itemRow.getItemId() + "]");
+            }
+          }
+        }
+        rs.close();
+        offsetCounter++;
+        long batchDur = System.currentTimeMillis() - batchStart;
+        ReportManager.getInstance().getStats().queryRan(batchDur);
+        if (hasMore) {
+          logger.info("Cached a batch of items.  Duration {} ms.", batchDur);
+        } else {
+          logger.info("No more batches of items found to cache.  Duration {} ms.", batchDur);
+        }
 
-			} while (hasMore);
-		} catch (Exception e) {
-			logger.error("Unable to cache items (batched queries) - {}",
-					e.getMessage(), e);
-			return false;
-		}
-		long dur = System.currentTimeMillis() - start;
-		logger.info("Cached items (batched queries).  Total duration {} ms.",
-				dur);
-		ReportManager.getInstance().getStats().incNumGrandTotalItems(attachmentsCache.size());
-		return true;
-	}
+      } while (hasMore);
+    } catch (Exception e) {
+      logger.error("Unable to cache items (batched queries) - {}", e.getMessage(), e);
+      return false;
+    }
+    long dur = System.currentTimeMillis() - start;
+    logger.info("Cached items (batched queries).  Total duration {} ms.", dur);
+    ReportManager.getInstance().getStats().incNumGrandTotalItems(attachmentsCache.size());
+    return true;
+  }
 }

--- a/src/test/java/org/apereo/openequella/tools/toolbox/CheckFilesDbTests.java
+++ b/src/test/java/org/apereo/openequella/tools/toolbox/CheckFilesDbTests.java
@@ -38,782 +38,540 @@ import org.junit.Test;
 public class CheckFilesDbTests {
   private static Logger LOGGER = LogManager.getLogger(Config.class);
 
-  private static final int INST_XA_NUM_OF_ALL_RESULTS = 22;
-  private static final int INST_XA_NUM_OF_ERR_RESULTS = 20;
-  private static final int INST_XB_NUM_OF_ALL_RESULTS = 24;
-  private static final int INST_XB_NUM_OF_ERR_RESULTS = 22;
-  private static final int INST_XC_COLL_FS2_NUM_ALL_RESULTS = 29;
-  private static final int INST_XC_COLL_FS2_NUM_ERR_RESULTS = 20;
-  private static final int INST_XD_COLL_LR_NUM_ALL_RESULTS = 30;
-  private static final int INST_XD_COLL_LR_NUM_ERR_RESULTS = 20;
-  private static final int INST_ALL_NUM_OF_ALL_RESULTS = 54;
-  private static final int INST_ALL_NUM_OF_ERR_RESULTS = 25;
-  private static final int OFFSET_FOR_QUERY_STATEMENT = 3;
+	private final static int INST_XA_NUM_OF_ALL_RESULTS = 22;
+	private final static int INST_XA_NUM_OF_ERR_RESULTS = 20;
+	private final static int INST_XB_NUM_OF_ALL_RESULTS = 24;
+	private final static int INST_XB_NUM_OF_ERR_RESULTS = 22;
+	private final static int INST_XC_COLL_FS2_NUM_ALL_RESULTS = 29;
+	private final static int INST_XC_COLL_FS2_NUM_ERR_RESULTS = 20;
+	private final static int INST_XD_COLL_LR_NUM_ALL_RESULTS = 30;
+	private final static int INST_XD_COLL_LR_NUM_ERR_RESULTS = 20;
+	private final static int INST_ALL_NUM_OF_ALL_RESULTS = 54;
+	private final static int INST_ALL_NUM_OF_ERR_RESULTS = 25;
+	private final static int OFFSET_FOR_QUERY_STATEMENT = 3;
 
-  @Test
-  public void testGeneralInstitutionInstXa() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXa");
-    Config.getInstance().checkConfigsCheckFiles();
+	@Test
+	public void testGeneralInstitutionInstXa() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXa");
+		Config.getInstance().checkConfigsCheckFiles();
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertTrue(CheckFilesDriver.run());
-    assertTrue(CheckFilesDriver.finalizeRun());
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-    confirmResultsInstitutionXaAllCollections(
-        ReportManager.getInstance().getAllStatsWriterList(),
-        ReportManager.getInstance().getErrorStatsWriterList());
-    assertEquals(
-        ReportManager.getInstance()
-            .getAllStatsWriterList()
-            .get(INST_XA_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
-        "# Of queries ran,6");
-  }
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsInstitutionXaAllCollections(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XA_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,6");
+	}
 
-  @Test
-  public void testGeneralInstitutionInstXb() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXb");
-    Config.getInstance().checkConfigsCheckFiles();
+	@Test
+	public void testGeneralInstitutionInstXb() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXb");
+		Config.getInstance().checkConfigsCheckFiles();
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertTrue(CheckFilesDriver.run());
-    assertTrue(CheckFilesDriver.finalizeRun());
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-    confirmResultsInstitutionXbAllCollections(
-        ReportManager.getInstance().getAllStatsWriterList(),
-        ReportManager.getInstance().getErrorStatsWriterList());
-    assertEquals(
-        ReportManager.getInstance()
-            .getAllStatsWriterList()
-            .get(INST_XB_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
-        "# Of queries ran,8");
-  }
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsInstitutionXbAllCollections(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XB_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,8");
+	}
 
-  @Test
-  public void testSpecialCharacters() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXc");
-    // Learning Resources
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "1874");
-    Config.getInstance().checkConfigsCheckFiles();
+	@Test
+	public void testSpecialCharacters() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXc");
+		// Learning Resources
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "1874");
+		Config.getInstance().checkConfigsCheckFiles();
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertTrue(CheckFilesDriver.run());
-    assertTrue(CheckFilesDriver.finalizeRun());
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-    confirmResultsInstitutionXcFS2Collection(
-        ReportManager.getInstance().getAllStatsWriterList(),
-        ReportManager.getInstance().getErrorStatsWriterList());
-    assertEquals(
-        ReportManager.getInstance()
-            .getAllStatsWriterList()
-            .get(INST_XC_COLL_FS2_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
-        "# Of queries ran,5");
-  }
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsInstitutionXcFS2Collection(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XC_COLL_FS2_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,5");
+	}
 
-  @Test
-  public void testFilterByInstitutionAndCollection() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
-    // Learning Resources
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
-    Config.getInstance().checkConfigsCheckFiles();
+	@Test
+	public void testFilterByInstitutionAndCollection() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
+		// Learning Resources
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
+		Config.getInstance().checkConfigsCheckFiles();
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertTrue(CheckFilesDriver.run());
-    assertTrue(CheckFilesDriver.finalizeRun());
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-    confirmResultsFilterByInstitutionXdAndCollection(
-        ReportManager.getInstance().getAllStatsWriterList(),
-        ReportManager.getInstance().getErrorStatsWriterList());
-    assertEquals(
-        ReportManager.getInstance()
-            .getAllStatsWriterList()
-            .get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
-        "# Of queries ran,14");
-  }
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsFilterByInstitutionXdAndCollection(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,14");
+	}
 
-  @Test
-  public void testFilterByInstitutionAndCollectionBatchedBy2() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
-    // Learning Resources
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
-    Config.getInstance()
-        .setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
-    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "2");
-    Config.getInstance().checkConfigsCheckFiles();
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertTrue(CheckFilesDriver.run());
-    assertTrue(CheckFilesDriver.finalizeRun());
+	@Test
+	public void testFilterByInstitutionAndCollectionBatchedBy2() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
+		// Learning Resources
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
+		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
+		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "2");
+		Config.getInstance().checkConfigsCheckFiles();
 
-    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-    confirmResultsFilterByInstitutionXdAndCollection(
-        ReportManager.getInstance().getAllStatsWriterList(),
-        ReportManager.getInstance().getErrorStatsWriterList());
-    assertEquals(
-        ReportManager.getInstance()
-            .getAllStatsWriterList()
-            .get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
-        "# Of queries ran,19");
-  }
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-  @Test
-  public void testFilterByInstitutionAndCollectionBatchedBy9() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
-    // Learning Resources
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
-    Config.getInstance()
-        .setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
-    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "9");
-    Config.getInstance().checkConfigsCheckFiles();
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsFilterByInstitutionXdAndCollection(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,19");
+	}
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertTrue(CheckFilesDriver.run());
-    assertTrue(CheckFilesDriver.finalizeRun());
+	@Test
+	public void testFilterByInstitutionAndCollectionBatchedBy9() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
+		// Learning Resources
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
+		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
+		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "9");
+		Config.getInstance().checkConfigsCheckFiles();
 
-    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-    confirmResultsFilterByInstitutionXdAndCollection(
-        ReportManager.getInstance().getAllStatsWriterList(),
-        ReportManager.getInstance().getErrorStatsWriterList());
-    assertEquals(
-        ReportManager.getInstance()
-            .getAllStatsWriterList()
-            .get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
-        "# Of queries ran,16");
-  }
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-  @Test
-  public void testFilterByInstitutionAndCollectionBatchedBy100() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
-    // Learning Resources
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
-    Config.getInstance()
-        .setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
-    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "100");
-    Config.getInstance().checkConfigsCheckFiles();
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsFilterByInstitutionXdAndCollection(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,16");
+	}
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertTrue(CheckFilesDriver.run());
-    assertTrue(CheckFilesDriver.finalizeRun());
+	@Test
+	public void testFilterByInstitutionAndCollectionBatchedBy100() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
+		// Learning Resources
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
+		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
+		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "100");
+		Config.getInstance().checkConfigsCheckFiles();
 
-    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-    confirmResultsFilterByInstitutionXdAndCollection(
-        ReportManager.getInstance().getAllStatsWriterList(),
-        ReportManager.getInstance().getErrorStatsWriterList());
-    assertEquals(
-        ReportManager.getInstance()
-            .getAllStatsWriterList()
-            .get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
-        "# Of queries ran,15");
-  }
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-  @Test
-  public void testAllInstitutions() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance().checkConfigsCheckFiles();
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsFilterByInstitutionXdAndCollection(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,15");
+	}
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertTrue(CheckFilesDriver.run());
-    assertTrue(CheckFilesDriver.finalizeRun());
+	@Test
+	public void testAllInstitutions() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().checkConfigsCheckFiles();
 
-    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-    confirmResultsAllInstitutions(
-        ReportManager.getInstance().getAllStatsWriterList(),
-        ReportManager.getInstance().getErrorStatsWriterList());
-    assertEquals(
-        ReportManager.getInstance()
-            .getAllStatsWriterList()
-            .get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
-        "# Of queries ran,30");
-  }
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-  @Test
-  public void testAllInstitutionsBatchBy1() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance()
-        .setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
-    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "1");
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsAllInstitutions(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,30");
+	}
 
-    Config.getInstance().checkConfigsCheckFiles();
+	@Test
+	public void testAllInstitutionsConfirmInlineBatchedByDefault() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE.name());
+		Config.getInstance().checkConfigsCheckFiles();
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertTrue(CheckFilesDriver.run());
-    assertTrue(CheckFilesDriver.finalizeRun());
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-    confirmResultsAllInstitutions(
-        ReportManager.getInstance().getAllStatsWriterList(),
-        ReportManager.getInstance().getErrorStatsWriterList());
-    assertEquals(
-        ReportManager.getInstance()
-            .getAllStatsWriterList()
-            .get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
-        "# Of queries ran,56");
-  }
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsAllInstitutions(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals("# Of queries ran,32", ReportManager.getInstance().getAllStatsWriterList().get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT));
+	}
 
-  @Test
-  public void testAllInstitutionsBatchBy10() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance()
-        .setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
-    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "10");
+	@Test
+	public void testAllInstitutionsConfirmInlineBatchedBy1() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE.name());
+		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "1");
+		Config.getInstance().checkConfigsCheckFiles();
 
-    Config.getInstance().checkConfigsCheckFiles();
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertTrue(CheckFilesDriver.run());
-    assertTrue(CheckFilesDriver.finalizeRun());
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsAllInstitutions(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals("# Of queries ran,56", ReportManager.getInstance().getAllStatsWriterList().get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT));
+	}
 
-    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-    confirmResultsAllInstitutions(
-        ReportManager.getInstance().getAllStatsWriterList(),
-        ReportManager.getInstance().getErrorStatsWriterList());
-    assertEquals(
-        ReportManager.getInstance()
-            .getAllStatsWriterList()
-            .get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
-        "# Of queries ran,33");
-  }
+	@Test
+	public void testAllInstitutionsBatchBy1() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
+		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "1");
 
-  @Test
-  public void testItemsInSingleQueryInstitutionFilterBad() {
-    Config.reset();
-    TestUtils.buildCheckFilesGeneralDbProps();
-    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "swirl");
-    Config.getInstance().checkConfigsCheckFiles();
+		Config.getInstance().checkConfigsCheckFiles();
 
-    assertTrue(CheckFilesDriver.setup(true));
-    assertFalse(CheckFilesDriver.run());
-    assertTrue(ReportManager.getInstance().hasFatalErrors());
-    assertEquals(
-        "Utility should state the short to filter by is not in the cache.",
-        ReportManager.getInstance().getFatalErrors().get(0),
-        "The institution shortname to filter by [swirl] is not in the institution cache.");
-  }
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-  private void confirmResultsAllInstitutions(List<String> allOriginal, List<String> errOriginal) {
-    assertEquals(INST_ALL_NUM_OF_ALL_RESULTS, allOriginal.size());
-    // This is the primary flow that will change when new items / institutions are added to the test
-    // institution.
-    // Sort the results in a sandbox to make checking results a bit simplier
-    List<String> all = new ArrayList<>();
-    all.addAll(allOriginal);
-    Collections.sort(all.subList(7, all.size()));
-    List<String> err = new ArrayList<>();
-    err.addAll(errOriginal);
-    Collections.sort(err.subList(7, err.size()));
-    int idx = 7;
-    assertEquals(all.get(idx++), "# Of ALL Attachments,34");
-    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
-    assertEquals(all.get(idx++), "# Of Items affected,5");
-    assertEquals(all.get(idx++), "# Of Items,26");
-    assertEquals(all.get(idx++), "# Of MISSING Attachments,5");
-    idx += 8; // Skip the non-critical rows
-    assertEquals(
-        all.get(idx++),
-        "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0a16eb9d-88af-4951-82bb-40da96516a2f,1,LIVE,file,16fd1eea-86bd-46a4-ae7b-c4b8686bc5dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-    assertEquals(
-        all.get(idx++),
-        "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,f61dc75f-62ca-4cbb-abf2-89bd489cb875,1,LIVE,file,d3e8a4db-f36d-4ff7-a074-728ade56f1d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-    assertEquals(
-        all.get(idx++),
-        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d70fa56f-214a-4233-923c-1df83a7c48c1,1,LIVE,file,12abbdce-ffea-4627-aa37-c890cd860a47,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,4a0d9c5d-0197-45b8-8c48-7b947ae9c499,1,LIVE,file,f56b2e48-0c68-42e1-8f79-6aa206c0a259,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,471ba862-8ab9-4b8f-92f5-0f53ad2cad4a,1,LIVE,file,0ddbd2bb-80f5-4ce4-ac26-590cb2e7a03f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,2395ec79-9925-46d6-af54-e6eb21dbfe0a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,39d8186f-6091-4c05-b41c-a907c63f8040,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"áéíóú¿¡üñ.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,416eb301-0ae6-4cb8-925f-02c6cdc61a7f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename with spaces.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,69885964-17f4-47a0-b417-06c1ede16617,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"slashes \\ are fun.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,6ee078cf-5725-438f-a3e0-937130d50277,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,836a7eb4-4897-44cc-9609-e843cbd46bba,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"ascii char \\ test +  . ~ $|=><`#^%&:}{ ]*[\")'(!-;?_,.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,bd2832e9-7d33-4ed6-8b85-15578f629ff5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"semi colons ; test.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,e81439a0-e948-4286-963a-008c5119c2c1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\" الأَبْجَدِيَّة.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,ef97a206-79c8-4235-b078-eaf58025ab29,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0b68c63f-afe7-4f35-b91c-f38609500384,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,19fc300e-290d-49aa-9023-63b6e40b81a9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,4c6f102e-6daf-48f8-aafb-0958b762ee62,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,66995857-0006-467a-91b3-470ac8ea59a0,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7015bfb5-53e0-4c7c-8c7d-a70db97c3441,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,757744c2-0f28-42dd-9884-e3bc548062e9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7643df39-86d6-43aa-af77-3ec3bc6d7f1e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d1a7cd84-295b-4538-815f-d9e35e47bc9e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d5c80e2f-e23e-4dfe-83d7-99877b974d2b,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,dc4a68d0-4209-440f-9d63-de6122162538,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXe,56396b0e-6923-41b9-b936-95475082a213,58d505f8-beef-47d6-a8bb-f52827ccae47,1,LIVE,file,d91f602c-d7f3-4238-a3cc-28df52afb0d9,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-    assertEquals(
-        all.get(idx++),
-        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8b594882-5805-4461-8970-d49c8ce41fb9,1,LIVE,file,fb3c52f6-4d9e-4232-bc1c-64e8d3da36b5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-    assertEquals(
-        all.get(idx++),
-        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8f5254e0-5b0f-4cfe-9af0-9ce2c5d784c5,1,LIVE,file,0578860d-65d7-44bf-8614-08469f268721,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-    assertEquals(
-        all.get(idx++),
-        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d8d002f7-63db-4c0c-bf9e-38d6334af37e,1,LIVE,file,3b24bdd0-f4d7-4bb3-a1cc-383faea4f981,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,febe7a26-a556-4b96-bf0b-ff441e525a98,1,LIVE,file,89d0ec7a-0724-48ff-adcf-f29099574f01,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test2.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,12f54be4-e536-482d-a7fe-f262ac086b28,1,LIVE,file,66c08dc8-d86f-49eb-84df-20e17e3483d2,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,bfc4e251-f9ba-4c0a-8fea-b37634c5997c,1,LIVE,file,14ec0166-7331-4fdf-8e94-4358aa78728c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "oeqgeneral,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,79b7fa12-7e96-46b1-a8dc-57eeb4dc799a,1,LIVE,file,a8b37c17-a30e-4fc9-9b41-f4fafa8f96c2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsAllInstitutions(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,56");
+	}
 
-    assertEquals(INST_ALL_NUM_OF_ERR_RESULTS, err.size());
+	@Test
+	public void testAllInstitutionsBatchBy10() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
+		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "10");
 
-    idx = 7;
-    assertEquals(all.get(idx++), "# Of ALL Attachments,34");
-    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
-    assertEquals(all.get(idx++), "# Of Items affected,5");
-    assertEquals(all.get(idx++), "# Of Items,26");
-    assertEquals(all.get(idx++), "# Of MISSING Attachments,5");
-    idx += 8; // Skip the non-critical rows
-    assertEquals(
-        err.get(idx++),
-        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-    assertEquals(
-        err.get(idx++),
-        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        err.get(idx++),
-        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8f5254e0-5b0f-4cfe-9af0-9ce2c5d784c5,1,LIVE,file,0578860d-65d7-44bf-8614-08469f268721,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-    assertEquals(
-        err.get(idx++),
-        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d8d002f7-63db-4c0c-bf9e-38d6334af37e,1,LIVE,file,3b24bdd0-f4d7-4bb3-a1cc-383faea4f981,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-    assertEquals(
-        err.get(idx++),
-        "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,12f54be4-e536-482d-a7fe-f262ac086b28,1,LIVE,file,66c08dc8-d86f-49eb-84df-20e17e3483d2,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-  }
+		Config.getInstance().checkConfigsCheckFiles();
 
-  private void confirmResultsInstitutionXaAllCollections(List<String> all, List<String> err) {
-    assertEquals(INST_XA_NUM_OF_ALL_RESULTS, all.size());
+		assertTrue(CheckFilesDriver.setup(true));
+		assertTrue(CheckFilesDriver.run());
+		assertTrue(CheckFilesDriver.finalizeRun());
 
-    int idx = 7;
-    assertEquals(
-        all.get(idx++),
-        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-    assertEquals(
-        all.get(idx++),
-        "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,f61dc75f-62ca-4cbb-abf2-89bd489cb875,1,LIVE,file,d3e8a4db-f36d-4ff7-a074-728ade56f1d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0a16eb9d-88af-4951-82bb-40da96516a2f,1,LIVE,file,16fd1eea-86bd-46a4-ae7b-c4b8686bc5dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-    assertEquals(all.get(idx++), "Stats");
-    assertEquals(all.get(idx++), "# Of Items,2");
-    assertEquals(all.get(idx++), "# Of Items affected,0");
-    assertEquals(all.get(idx++), "# Of ALL Attachments,2");
-    assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
-    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+		confirmResultsAllInstitutions(ReportManager.getInstance().getAllStatsWriterList(),
+						ReportManager.getInstance().getErrorStatsWriterList());
+		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,33");
+	}
 
-    assertEquals(INST_XA_NUM_OF_ERR_RESULTS, err.size());
+	@Test
+	public void testItemsInSingleQueryInstitutionFilterBad() {
+		Config.reset();
+		TestUtils.buildCheckFilesGeneralDbProps();
+		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "swirl");
+		Config.getInstance().checkConfigsCheckFiles();
 
-    idx = 7;
-    assertEquals(
-        err.get(idx++),
-        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-    assertEquals(err.get(idx++), "Stats");
-    assertEquals(err.get(idx++), "# Of Items,2");
-    assertEquals(err.get(idx++), "# Of Items affected,0");
-    assertEquals(err.get(idx++), "# Of ALL Attachments,2");
-    assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
-    assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
-  }
+		assertTrue(CheckFilesDriver.setup(true));
+		assertFalse(CheckFilesDriver.run());
+		assertTrue(ReportManager.getInstance().hasFatalErrors());
+		assertEquals(
+				"Utility should state the short to filter by is not in the cache.",
+				ReportManager.getInstance().getFatalErrors().get(0),
+				"The institution shortname to filter by [swirl] is not in the institution cache.");
+	}
 
-  private void confirmResultsInstitutionXbAllCollections(List<String> all, List<String> err) {
-    assertEquals(INST_XB_NUM_OF_ALL_RESULTS, all.size());
 
-    int idx = 7;
-    assertEquals(
-        all.get(idx++),
-        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-    assertEquals(
-        all.get(idx++),
-        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,4a0d9c5d-0197-45b8-8c48-7b947ae9c499,1,LIVE,file,f56b2e48-0c68-42e1-8f79-6aa206c0a259,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-    assertEquals(
-        all.get(idx++),
-        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d70fa56f-214a-4233-923c-1df83a7c48c1,1,LIVE,file,12abbdce-ffea-4627-aa37-c890cd860a47,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-    assertEquals(all.get(idx++), "Stats");
-    assertEquals(all.get(idx++), "# Of Items,4");
-    assertEquals(all.get(idx++), "# Of Items affected,2");
-    assertEquals(all.get(idx++), "# Of ALL Attachments,4");
-    assertEquals(all.get(idx++), "# Of MISSING Attachments,2");
-    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+	private void confirmResultsAllInstitutions(List<String> allOriginal, List<String> errOriginal) {
+		assertEquals(INST_ALL_NUM_OF_ALL_RESULTS, allOriginal.size());
+		// This is the primary flow that will change when new items / institutions are added to the test institution.
+		// Sort the results in a sandbox to make checking results a bit simplier
+		List<String> all = new ArrayList<>();
+		all.addAll(allOriginal);
+		Collections.sort(all.subList(7, all.size()));
+		List<String> err = new ArrayList<>();
+		err.addAll(errOriginal);
+		Collections.sort(err.subList(7, err.size()));
+		int idx = 7;
+		assertEquals(all.get(idx++), "# Of ALL Attachments,34");
+		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+		assertEquals(all.get(idx++), "# Of Items affected,5");
+		assertEquals(all.get(idx++), "# Of Items,26");
+		assertEquals(all.get(idx++), "# Of MISSING Attachments,5");
+		idx+=8; //Skip the non-critical rows
+		assertEquals(all.get(idx++), "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0a16eb9d-88af-4951-82bb-40da96516a2f,1,LIVE,file,16fd1eea-86bd-46a4-ae7b-c4b8686bc5dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+		assertEquals(all.get(idx++), "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,f61dc75f-62ca-4cbb-abf2-89bd489cb875,1,LIVE,file,d3e8a4db-f36d-4ff7-a074-728ade56f1d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+		assertEquals(all.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+		assertEquals(all.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d70fa56f-214a-4233-923c-1df83a7c48c1,1,LIVE,file,12abbdce-ffea-4627-aa37-c890cd860a47,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+		assertEquals(all.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,4a0d9c5d-0197-45b8-8c48-7b947ae9c499,1,LIVE,file,f56b2e48-0c68-42e1-8f79-6aa206c0a259,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+		assertEquals(all.get(idx++), "instXc,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,471ba862-8ab9-4b8f-92f5-0f53ad2cad4a,1,LIVE,file,0ddbd2bb-80f5-4ce4-ac26-590cb2e7a03f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,2395ec79-9925-46d6-af54-e6eb21dbfe0a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,39d8186f-6091-4c05-b41c-a907c63f8040,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"áéíóú¿¡üñ.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,416eb301-0ae6-4cb8-925f-02c6cdc61a7f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename with spaces.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,69885964-17f4-47a0-b417-06c1ede16617,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"slashes \\ are fun.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,6ee078cf-5725-438f-a3e0-937130d50277,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,836a7eb4-4897-44cc-9609-e843cbd46bba,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"ascii char \\ test +  . ~ $|=><`#^%&:}{ ]*[\")'(!-;?_,.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,bd2832e9-7d33-4ed6-8b85-15578f629ff5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"semi colons ; test.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,e81439a0-e948-4286-963a-008c5119c2c1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\" الأَبْجَدِيَّة.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,ef97a206-79c8-4235-b078-eaf58025ab29,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0b68c63f-afe7-4f35-b91c-f38609500384,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,19fc300e-290d-49aa-9023-63b6e40b81a9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,4c6f102e-6daf-48f8-aafb-0958b762ee62,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,66995857-0006-467a-91b3-470ac8ea59a0,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7015bfb5-53e0-4c7c-8c7d-a70db97c3441,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,757744c2-0f28-42dd-9884-e3bc548062e9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7643df39-86d6-43aa-af77-3ec3bc6d7f1e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d1a7cd84-295b-4538-815f-d9e35e47bc9e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d5c80e2f-e23e-4dfe-83d7-99877b974d2b,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,dc4a68d0-4209-440f-9d63-de6122162538,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXe,56396b0e-6923-41b9-b936-95475082a213,58d505f8-beef-47d6-a8bb-f52827ccae47,1,LIVE,file,d91f602c-d7f3-4238-a3cc-28df52afb0d9,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+		assertEquals(all.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8b594882-5805-4461-8970-d49c8ce41fb9,1,LIVE,file,fb3c52f6-4d9e-4232-bc1c-64e8d3da36b5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+		assertEquals(all.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8f5254e0-5b0f-4cfe-9af0-9ce2c5d784c5,1,LIVE,file,0578860d-65d7-44bf-8614-08469f268721,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+		assertEquals(all.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d8d002f7-63db-4c0c-bf9e-38d6334af37e,1,LIVE,file,3b24bdd0-f4d7-4bb3-a1cc-383faea4f981,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+		assertEquals(all.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,febe7a26-a556-4b96-bf0b-ff441e525a98,1,LIVE,file,89d0ec7a-0724-48ff-adcf-f29099574f01,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test2.txt\",");
+		assertEquals(all.get(idx++), "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,12f54be4-e536-482d-a7fe-f262ac086b28,1,LIVE,file,66c08dc8-d86f-49eb-84df-20e17e3483d2,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+		assertEquals(all.get(idx++), "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,bfc4e251-f9ba-4c0a-8fea-b37634c5997c,1,LIVE,file,14ec0166-7331-4fdf-8e94-4358aa78728c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "oeqgeneral,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,79b7fa12-7e96-46b1-a8dc-57eeb4dc799a,1,LIVE,file,a8b37c17-a30e-4fc9-9b41-f4fafa8f96c2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
 
-    assertEquals(INST_XB_NUM_OF_ERR_RESULTS, err.size());
+		assertEquals(INST_ALL_NUM_OF_ERR_RESULTS, err.size());
 
-    idx = 7;
-    assertEquals(
-        err.get(idx++),
-        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-    assertEquals(
-        err.get(idx++),
-        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        err.get(idx++),
-        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-    assertEquals(err.get(idx++), "Stats");
-    assertEquals(err.get(idx++), "# Of Items,4");
-    assertEquals(err.get(idx++), "# Of Items affected,2");
-    assertEquals(err.get(idx++), "# Of ALL Attachments,4");
-    assertEquals(err.get(idx++), "# Of MISSING Attachments,2");
-    assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
-  }
+		idx = 7;
+		assertEquals(all.get(idx++), "# Of ALL Attachments,34");
+		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+		assertEquals(all.get(idx++), "# Of Items affected,5");
+		assertEquals(all.get(idx++), "# Of Items,26");
+		assertEquals(all.get(idx++), "# Of MISSING Attachments,5");
+		idx+=8; //Skip the non-critical rows
+		assertEquals(err.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+		assertEquals(err.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(err.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8f5254e0-5b0f-4cfe-9af0-9ce2c5d784c5,1,LIVE,file,0578860d-65d7-44bf-8614-08469f268721,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+		assertEquals(err.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d8d002f7-63db-4c0c-bf9e-38d6334af37e,1,LIVE,file,3b24bdd0-f4d7-4bb3-a1cc-383faea4f981,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+		assertEquals(err.get(idx++), "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,12f54be4-e536-482d-a7fe-f262ac086b28,1,LIVE,file,66c08dc8-d86f-49eb-84df-20e17e3483d2,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+	}
 
-  private void confirmResultsInstitutionXcFS2Collection(List<String> all, List<String> err) {
-    assertEquals(INST_XC_COLL_FS2_NUM_ALL_RESULTS, all.size());
+	private void confirmResultsInstitutionXaAllCollections(List<String> all, List<String> err) {
+		assertEquals(INST_XA_NUM_OF_ALL_RESULTS, all.size());
 
-    int idx = 7;
-    assertEquals(
-        all.get(idx++),
-        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,6ee078cf-5725-438f-a3e0-937130d50277,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,2395ec79-9925-46d6-af54-e6eb21dbfe0a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,ef97a206-79c8-4235-b078-eaf58025ab29,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,416eb301-0ae6-4cb8-925f-02c6cdc61a7f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename with spaces.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,836a7eb4-4897-44cc-9609-e843cbd46bba,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"ascii char \\ test +  . ~ $|=><`#^%&:}{ ]*[\")'(!-;?_,.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,39d8186f-6091-4c05-b41c-a907c63f8040,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"áéíóú¿¡üñ.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,e81439a0-e948-4286-963a-008c5119c2c1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\" الأَبْجَدِيَّة.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,bd2832e9-7d33-4ed6-8b85-15578f629ff5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"semi colons ; test.log\",");
-    assertEquals(
-        all.get(idx++),
-        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,69885964-17f4-47a0-b417-06c1ede16617,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"slashes \\ are fun.log\",");
-    assertEquals(all.get(idx++), "Stats");
-    assertEquals(all.get(idx++), "# Of Items,1");
-    assertEquals(all.get(idx++), "# Of Items affected,0");
-    assertEquals(all.get(idx++), "# Of ALL Attachments,9");
-    assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
-    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+		int idx = 7;
+		assertEquals(all.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+		assertEquals(all.get(idx++), "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,f61dc75f-62ca-4cbb-abf2-89bd489cb875,1,LIVE,file,d3e8a4db-f36d-4ff7-a074-728ade56f1d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+		assertEquals(all.get(idx++), "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0a16eb9d-88af-4951-82bb-40da96516a2f,1,LIVE,file,16fd1eea-86bd-46a4-ae7b-c4b8686bc5dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+		assertEquals(all.get(idx++), "Stats");
+		assertEquals(all.get(idx++), "# Of Items,2");
+		assertEquals(all.get(idx++), "# Of Items affected,0");
+		assertEquals(all.get(idx++), "# Of ALL Attachments,2");
+		assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
+		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
 
-    assertEquals(INST_XC_COLL_FS2_NUM_ERR_RESULTS, err.size());
+		assertEquals(INST_XA_NUM_OF_ERR_RESULTS, err.size());
 
-    idx = 7;
-    assertEquals(
-        err.get(idx++),
-        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-    assertEquals(err.get(idx++), "Stats");
-    assertEquals(err.get(idx++), "# Of Items,1");
-    assertEquals(err.get(idx++), "# Of Items affected,0");
-    assertEquals(err.get(idx++), "# Of ALL Attachments,9");
-    assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
-    assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
-  }
+		idx = 7;
+		assertEquals(err.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+		assertEquals(err.get(idx++), "Stats");
+		assertEquals(err.get(idx++), "# Of Items,2");
+		assertEquals(err.get(idx++), "# Of Items affected,0");
+		assertEquals(err.get(idx++), "# Of ALL Attachments,2");
+		assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
+		assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
+	}
 
-  private void confirmResultsFilterByInstitutionXdAndCollection(
-      List<String> all, List<String> err) {
-    assertEquals(INST_XD_COLL_LR_NUM_ALL_RESULTS, all.size());
+	private void confirmResultsInstitutionXbAllCollections(List<String> all, List<String> err) {
+		assertEquals(INST_XB_NUM_OF_ALL_RESULTS, all.size());
 
-    int idx = 7;
-    assertEquals(
-        all.get(idx++),
-        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7015bfb5-53e0-4c7c-8c7d-a70db97c3441,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7643df39-86d6-43aa-af77-3ec3bc6d7f1e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,dc4a68d0-4209-440f-9d63-de6122162538,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d1a7cd84-295b-4538-815f-d9e35e47bc9e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,66995857-0006-467a-91b3-470ac8ea59a0,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,757744c2-0f28-42dd-9884-e3bc548062e9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d5c80e2f-e23e-4dfe-83d7-99877b974d2b,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,19fc300e-290d-49aa-9023-63b6e40b81a9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,4c6f102e-6daf-48f8-aafb-0958b762ee62,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(
-        all.get(idx++),
-        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0b68c63f-afe7-4f35-b91c-f38609500384,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-    assertEquals(all.get(idx++), "Stats");
-    assertEquals(all.get(idx++), "# Of Items,10");
-    assertEquals(all.get(idx++), "# Of Items affected,0");
-    assertEquals(all.get(idx++), "# Of ALL Attachments,10");
-    assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
-    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+		int idx = 7;
+		assertEquals(all.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+		assertEquals(all.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,4a0d9c5d-0197-45b8-8c48-7b947ae9c499,1,LIVE,file,f56b2e48-0c68-42e1-8f79-6aa206c0a259,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+		assertEquals(all.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+		assertEquals(all.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d70fa56f-214a-4233-923c-1df83a7c48c1,1,LIVE,file,12abbdce-ffea-4627-aa37-c890cd860a47,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+		assertEquals(all.get(idx++), "Stats");
+		assertEquals(all.get(idx++), "# Of Items,4");
+		assertEquals(all.get(idx++), "# Of Items affected,2");
+		assertEquals(all.get(idx++), "# Of ALL Attachments,4");
+		assertEquals(all.get(idx++), "# Of MISSING Attachments,2");
+		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
 
-    assertEquals(INST_XD_COLL_LR_NUM_ERR_RESULTS, err.size());
+		assertEquals(INST_XB_NUM_OF_ERR_RESULTS, err.size());
 
-    idx = 7;
-    assertEquals(
-        err.get(idx++),
-        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-    assertEquals(err.get(idx++), "Stats");
-    assertEquals(err.get(idx++), "# Of Items,10");
-    assertEquals(err.get(idx++), "# Of Items affected,0");
-    assertEquals(err.get(idx++), "# Of ALL Attachments,10");
-    assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
-    assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
-  }
+		idx = 7;
+		assertEquals(err.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+		assertEquals(err.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(err.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+		assertEquals(err.get(idx++), "Stats");
+		assertEquals(err.get(idx++), "# Of Items,4");
+		assertEquals(err.get(idx++), "# Of Items affected,2");
+		assertEquals(err.get(idx++), "# Of ALL Attachments,4");
+		assertEquals(err.get(idx++), "# Of MISSING Attachments,2");
+		assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
+	}
 
-  private void confirmResultsAllInstitutionsAllItems(List<String> all, List<String> err) {
-    assertEquals(57, all.size());
 
-    int idx = 7;
-    assertEquals(
-        all.get(idx++),
-        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,8428e745-4cdb-4427-8b63-570c81401b2a,1,LIVE,[[Attachment type not set]],[[Attachment UUID not set]],No Att,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,fa6b69a3-4524-4797-93ed-5f9c4cbcb28f,1,LIVE,file,ebf79de1-a336-4886-bec7-3a060666f700,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"plus and spaces+.pdf\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,fa6b69a3-4524-4797-93ed-5f9c4cbcb28f,1,LIVE,file,1d961dd4-2e03-42f2-b028-7c59600c4241,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cceab569-d101-445f-a59d-5cd5500a2b0c,1,LIVE,file,22b26083-6f4f-42fe-abca-befee0eb92a9,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html.zip\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,d896a882-a86a-4f5e-9650-c5f13a6d89d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ) test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,c4307b91-58c9-4106-bf5b-816ba07e0c3d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ( test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,53d76799-35d3-4b3e-8634-3b1666b778f5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char \" test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,3e796f00-731c-4eb2-a483-d93796650099,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char : test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,be8d38ca-4216-444a-b388-fc8de5d782b6,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char & test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,9495760a-f8d1-4219-bbe7-0d6518d4bedf,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char control test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,21d6c550-2ff1-4112-84f6-1f0ca567b6dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test\\this.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,9db63958-5d1b-47b5-aa3d-0d569a598c72,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"|.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,0c85de42-66b7-4446-8e16-7166756214f6,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"*.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,ae61a098-cfc4-452f-8268-695fa0fee94c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"^.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,de9a3fcf-dd07-4e53-99df-ebde4b11c493,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"..txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,a700d38d-bbd4-4b9a-a1fd-4438607bfec8,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"\\.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,3749c0c3-fcf8-427e-98a2-61fd3184f03a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char % [ ] { } ( ) asdf\\ asdf  \\ asdf = 123 \\ test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,8672147b-3d81-4ca4-84df-41829107e11b,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"fileWithPeriodAfterNonleadingBackslashesRoot\\fileWithPeriodAfterNonleadingBackslashesSubName\\.fileWithPeriodAfterNonleadingBackslashesLeaf\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,bb8f1968-eff2-41b2-9a68-705c4d7f1f2d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ? test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,e92dfc79-1a30-4682-ab01-b231b70004a1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ' test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,bd554963-2c55-4da9-9a9f-940ae41b6be1,1,LIVE,file,9d98468c-a040-4dfb-aa94-5500a6ccf467,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,25ecc776-076b-4c9b-b2cf-1f3808007d9d,1,LIVE,file,9465f317-d2a7-48d3-a6e2-27e142b534e8,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,dfe3782d-54b6-4aa2-873d-23c2ef6bf2a8,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,a78040c6-4bd6-48ff-be8a-ce90bcf8f81e,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,726cb654-3f24-4f6b-8c50-02cc5ddbdfeb,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,custom,9827302b-9012-4314-8f1b-053897eadd00,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,395d0c73-dfad-4f01-bb6b-cbcef11ed4db,1,LIVE,file,a4920601-3e3d-4c11-9560-8b9bd9c1baf3,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting2,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,4d410ae3-072a-445c-a2e3-04a0bea8aceb,1,LIVE,file,d95a8e4d-f5b3-4280-a2fc-3bdd68acc26d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,2ed14dab-9103-4073-b8ce-1f134c40e7c5,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,7bf92ca9-84c3-4d9c-8917-d8f806443e10,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,369f980e-b3ae-4b47-9d2f-461a96230828,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cb0461fb-1d0a-4942-ba75-49ed630f0e28,1,LIVE,file,12780b70-31e4-4a93-9e1b-13ab7d09eb78,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cb0461fb-1d0a-4942-ba75-49ed630f0e28,1,LIVE,file,f5f61878-c139-42e1-8ccf-fd985f7c5667,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,attachment,8169c3d4-f6ed-4255-b17c-9f3136f1b85f,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,9964d765-6ead-4fb1-9752-166e7dbf206c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,2d4fe299-4eaf-499d-956e-571c30f13fa0,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"الأَبْجَدِيَّة.pdf\",");
-    assertEquals(
-        all.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,a0954d15-9e55-449a-9f04-a1c065e92440,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.pdf\",");
-    assertEquals(all.get(idx++), "Stats");
-    assertEquals(all.get(idx++), "# Of Items,12");
-    assertEquals(all.get(idx++), "# Of Items affected,2");
-    assertEquals(all.get(idx++), "# Of ALL Attachments,36");
-    assertEquals(all.get(idx++), "# Of MISSING Attachments,2");
-    assertEquals(all.get(idx++), "# Of IGNORED Attachments,5");
+	private void confirmResultsInstitutionXcFS2Collection(List<String> all, List<String> err) {
+		assertEquals(INST_XC_COLL_FS2_NUM_ALL_RESULTS, all.size());
 
-    assertEquals(22, err.size());
+		int idx = 7;
+		assertEquals(all.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,6ee078cf-5725-438f-a3e0-937130d50277,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,2395ec79-9925-46d6-af54-e6eb21dbfe0a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,ef97a206-79c8-4235-b078-eaf58025ab29,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,416eb301-0ae6-4cb8-925f-02c6cdc61a7f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename with spaces.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,836a7eb4-4897-44cc-9609-e843cbd46bba,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"ascii char \\ test +  . ~ $|=><`#^%&:}{ ]*[\")'(!-;?_,.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,39d8186f-6091-4c05-b41c-a907c63f8040,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"áéíóú¿¡üñ.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,e81439a0-e948-4286-963a-008c5119c2c1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\" الأَبْجَدِيَّة.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,bd2832e9-7d33-4ed6-8b85-15578f629ff5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"semi colons ; test.log\",");
+		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,69885964-17f4-47a0-b417-06c1ede16617,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"slashes \\ are fun.log\",");
+		assertEquals(all.get(idx++), "Stats");
+		assertEquals(all.get(idx++), "# Of Items,1");
+		assertEquals(all.get(idx++), "# Of Items affected,0");
+		assertEquals(all.get(idx++), "# Of ALL Attachments,9");
+		assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
+		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
 
-    idx = 7;
-    assertEquals(
-        err.get(idx++),
-        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-    assertEquals(
-        err.get(idx++),
-        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,25ecc776-076b-4c9b-b2cf-1f3808007d9d,1,LIVE,file,9465f317-d2a7-48d3-a6e2-27e142b534e8,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
-    assertEquals(
-        err.get(idx++),
-        "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,a78040c6-4bd6-48ff-be8a-ce90bcf8f81e,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
-    assertEquals(err.get(idx++), "Stats");
-    assertEquals(err.get(idx++), "# Of Items,12");
-    assertEquals(err.get(idx++), "# Of Items affected,2");
-    assertEquals(err.get(idx++), "# Of ALL Attachments,36");
-    assertEquals(err.get(idx++), "# Of MISSING Attachments,2");
-    assertEquals(err.get(idx++), "# Of IGNORED Attachments,5");
-  }
+		assertEquals(INST_XC_COLL_FS2_NUM_ERR_RESULTS, err.size());
+
+		idx = 7;
+		assertEquals(err.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+		assertEquals(err.get(idx++), "Stats");
+		assertEquals(err.get(idx++), "# Of Items,1");
+		assertEquals(err.get(idx++), "# Of Items affected,0");
+		assertEquals(err.get(idx++), "# Of ALL Attachments,9");
+		assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
+		assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
+	}
+
+
+
+	private void confirmResultsFilterByInstitutionXdAndCollection(List<String> all, List<String> err) {
+		assertEquals(INST_XD_COLL_LR_NUM_ALL_RESULTS, all.size());
+
+		int idx = 7;
+		assertEquals(all.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7015bfb5-53e0-4c7c-8c7d-a70db97c3441,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7643df39-86d6-43aa-af77-3ec3bc6d7f1e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,dc4a68d0-4209-440f-9d63-de6122162538,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d1a7cd84-295b-4538-815f-d9e35e47bc9e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,66995857-0006-467a-91b3-470ac8ea59a0,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,757744c2-0f28-42dd-9884-e3bc548062e9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d5c80e2f-e23e-4dfe-83d7-99877b974d2b,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,19fc300e-290d-49aa-9023-63b6e40b81a9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,4c6f102e-6daf-48f8-aafb-0958b762ee62,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0b68c63f-afe7-4f35-b91c-f38609500384,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+		assertEquals(all.get(idx++), "Stats");
+		assertEquals(all.get(idx++), "# Of Items,10");
+		assertEquals(all.get(idx++), "# Of Items affected,0");
+		assertEquals(all.get(idx++), "# Of ALL Attachments,10");
+		assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
+		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+
+		assertEquals(INST_XD_COLL_LR_NUM_ERR_RESULTS, err.size());
+
+		idx = 7;
+		assertEquals(err.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+		assertEquals(err.get(idx++), "Stats");
+		assertEquals(err.get(idx++), "# Of Items,10");
+		assertEquals(err.get(idx++), "# Of Items affected,0");
+		assertEquals(err.get(idx++), "# Of ALL Attachments,10");
+		assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
+		assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
+	}
+
+
+	private void confirmResultsAllInstitutionsAllItems(List<String> all, List<String> err) {
+		assertEquals(57, all.size());
+
+		int idx = 7;
+		assertEquals(all.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,8428e745-4cdb-4427-8b63-570c81401b2a,1,LIVE,[[Attachment type not set]],[[Attachment UUID not set]],No Att,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,fa6b69a3-4524-4797-93ed-5f9c4cbcb28f,1,LIVE,file,ebf79de1-a336-4886-bec7-3a060666f700,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"plus and spaces+.pdf\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,fa6b69a3-4524-4797-93ed-5f9c4cbcb28f,1,LIVE,file,1d961dd4-2e03-42f2-b028-7c59600c4241,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cceab569-d101-445f-a59d-5cd5500a2b0c,1,LIVE,file,22b26083-6f4f-42fe-abca-befee0eb92a9,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html.zip\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,d896a882-a86a-4f5e-9650-c5f13a6d89d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ) test.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,c4307b91-58c9-4106-bf5b-816ba07e0c3d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ( test.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,53d76799-35d3-4b3e-8634-3b1666b778f5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char \" test.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,3e796f00-731c-4eb2-a483-d93796650099,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char : test.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,be8d38ca-4216-444a-b388-fc8de5d782b6,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char & test.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,9495760a-f8d1-4219-bbe7-0d6518d4bedf,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char control test.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,21d6c550-2ff1-4112-84f6-1f0ca567b6dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test\\this.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,9db63958-5d1b-47b5-aa3d-0d569a598c72,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"|.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,0c85de42-66b7-4446-8e16-7166756214f6,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"*.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,ae61a098-cfc4-452f-8268-695fa0fee94c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"^.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,de9a3fcf-dd07-4e53-99df-ebde4b11c493,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"..txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,a700d38d-bbd4-4b9a-a1fd-4438607bfec8,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"\\.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,3749c0c3-fcf8-427e-98a2-61fd3184f03a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char % [ ] { } ( ) asdf\\ asdf  \\ asdf = 123 \\ test.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,8672147b-3d81-4ca4-84df-41829107e11b,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"fileWithPeriodAfterNonleadingBackslashesRoot\\fileWithPeriodAfterNonleadingBackslashesSubName\\.fileWithPeriodAfterNonleadingBackslashesLeaf\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,bb8f1968-eff2-41b2-9a68-705c4d7f1f2d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ? test.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,e92dfc79-1a30-4682-ab01-b231b70004a1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ' test.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,bd554963-2c55-4da9-9a9f-940ae41b6be1,1,LIVE,file,9d98468c-a040-4dfb-aa94-5500a6ccf467,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,25ecc776-076b-4c9b-b2cf-1f3808007d9d,1,LIVE,file,9465f317-d2a7-48d3-a6e2-27e142b534e8,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,dfe3782d-54b6-4aa2-873d-23c2ef6bf2a8,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,a78040c6-4bd6-48ff-be8a-ce90bcf8f81e,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,726cb654-3f24-4f6b-8c50-02cc5ddbdfeb,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,custom,9827302b-9012-4314-8f1b-053897eadd00,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,395d0c73-dfad-4f01-bb6b-cbcef11ed4db,1,LIVE,file,a4920601-3e3d-4c11-9560-8b9bd9c1baf3,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting2,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,4d410ae3-072a-445c-a2e3-04a0bea8aceb,1,LIVE,file,d95a8e4d-f5b3-4280-a2fc-3bdd68acc26d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,2ed14dab-9103-4073-b8ce-1f134c40e7c5,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,7bf92ca9-84c3-4d9c-8917-d8f806443e10,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,369f980e-b3ae-4b47-9d2f-461a96230828,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cb0461fb-1d0a-4942-ba75-49ed630f0e28,1,LIVE,file,12780b70-31e4-4a93-9e1b-13ab7d09eb78,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cb0461fb-1d0a-4942-ba75-49ed630f0e28,1,LIVE,file,f5f61878-c139-42e1-8ccf-fd985f7c5667,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,attachment,8169c3d4-f6ed-4255-b17c-9f3136f1b85f,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,9964d765-6ead-4fb1-9752-166e7dbf206c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,2d4fe299-4eaf-499d-956e-571c30f13fa0,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"الأَبْجَدِيَّة.pdf\",");
+		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,a0954d15-9e55-449a-9f04-a1c065e92440,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.pdf\",");
+		assertEquals(all.get(idx++), "Stats");
+		assertEquals(all.get(idx++), "# Of Items,12");
+		assertEquals(all.get(idx++), "# Of Items affected,2");
+		assertEquals(all.get(idx++), "# Of ALL Attachments,36");
+		assertEquals(all.get(idx++), "# Of MISSING Attachments,2");
+		assertEquals(all.get(idx++), "# Of IGNORED Attachments,5");
+
+		assertEquals(22, err.size());
+
+		idx = 7;
+		assertEquals(err.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+		assertEquals(err.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,25ecc776-076b-4c9b-b2cf-1f3808007d9d,1,LIVE,file,9465f317-d2a7-48d3-a6e2-27e142b534e8,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
+		assertEquals(err.get(idx++), "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,a78040c6-4bd6-48ff-be8a-ce90bcf8f81e,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
+		assertEquals(err.get(idx++), "Stats");
+		assertEquals(err.get(idx++), "# Of Items,12");
+		assertEquals(err.get(idx++), "# Of Items affected,2");
+		assertEquals(err.get(idx++), "# Of ALL Attachments,36");
+		assertEquals(err.get(idx++), "# Of MISSING Attachments,2");
+		assertEquals(err.get(idx++), "# Of IGNORED Attachments,5");
+	}
 }

--- a/src/test/java/org/apereo/openequella/tools/toolbox/CheckFilesDbTests.java
+++ b/src/test/java/org/apereo/openequella/tools/toolbox/CheckFilesDbTests.java
@@ -38,540 +38,837 @@ import org.junit.Test;
 public class CheckFilesDbTests {
   private static Logger LOGGER = LogManager.getLogger(Config.class);
 
-	private final static int INST_XA_NUM_OF_ALL_RESULTS = 22;
-	private final static int INST_XA_NUM_OF_ERR_RESULTS = 20;
-	private final static int INST_XB_NUM_OF_ALL_RESULTS = 24;
-	private final static int INST_XB_NUM_OF_ERR_RESULTS = 22;
-	private final static int INST_XC_COLL_FS2_NUM_ALL_RESULTS = 29;
-	private final static int INST_XC_COLL_FS2_NUM_ERR_RESULTS = 20;
-	private final static int INST_XD_COLL_LR_NUM_ALL_RESULTS = 30;
-	private final static int INST_XD_COLL_LR_NUM_ERR_RESULTS = 20;
-	private final static int INST_ALL_NUM_OF_ALL_RESULTS = 54;
-	private final static int INST_ALL_NUM_OF_ERR_RESULTS = 25;
-	private final static int OFFSET_FOR_QUERY_STATEMENT = 3;
-
-	@Test
-	public void testGeneralInstitutionInstXa() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXa");
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsInstitutionXaAllCollections(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XA_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,6");
-	}
-
-	@Test
-	public void testGeneralInstitutionInstXb() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXb");
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsInstitutionXbAllCollections(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XB_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,8");
-	}
-
-	@Test
-	public void testSpecialCharacters() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXc");
-		// Learning Resources
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "1874");
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsInstitutionXcFS2Collection(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XC_COLL_FS2_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,5");
-	}
-
-	@Test
-	public void testFilterByInstitutionAndCollection() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
-		// Learning Resources
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsFilterByInstitutionXdAndCollection(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,14");
-	}
-
-
-	@Test
-	public void testFilterByInstitutionAndCollectionBatchedBy2() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
-		// Learning Resources
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
-		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
-		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "2");
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsFilterByInstitutionXdAndCollection(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,19");
-	}
-
-	@Test
-	public void testFilterByInstitutionAndCollectionBatchedBy9() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
-		// Learning Resources
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
-		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
-		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "9");
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsFilterByInstitutionXdAndCollection(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,16");
-	}
-
-	@Test
-	public void testFilterByInstitutionAndCollectionBatchedBy100() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
-		// Learning Resources
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
-		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
-		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "100");
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsFilterByInstitutionXdAndCollection(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,15");
-	}
-
-	@Test
-	public void testAllInstitutions() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsAllInstitutions(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,30");
-	}
-
-	@Test
-	public void testAllInstitutionsConfirmInlineBatchedByDefault() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE.name());
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsAllInstitutions(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals("# Of queries ran,32", ReportManager.getInstance().getAllStatsWriterList().get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT));
-	}
-
-	@Test
-	public void testAllInstitutionsConfirmInlineBatchedBy1() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE.name());
-		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "1");
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsAllInstitutions(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals("# Of queries ran,56", ReportManager.getInstance().getAllStatsWriterList().get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT));
-	}
-
-	@Test
-	public void testAllInstitutionsBatchBy1() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
-		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "1");
-
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsAllInstitutions(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,56");
-	}
-
-	@Test
-	public void testAllInstitutionsBatchBy10() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
-		Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "10");
-
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertTrue(CheckFilesDriver.run());
-		assertTrue(CheckFilesDriver.finalizeRun());
-
-		TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
-		TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
-		confirmResultsAllInstitutions(ReportManager.getInstance().getAllStatsWriterList(),
-						ReportManager.getInstance().getErrorStatsWriterList());
-		assertEquals(ReportManager.getInstance().getAllStatsWriterList().get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT), "# Of queries ran,33");
-	}
-
-	@Test
-	public void testItemsInSingleQueryInstitutionFilterBad() {
-		Config.reset();
-		TestUtils.buildCheckFilesGeneralDbProps();
-		Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
-		Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "swirl");
-		Config.getInstance().checkConfigsCheckFiles();
-
-		assertTrue(CheckFilesDriver.setup(true));
-		assertFalse(CheckFilesDriver.run());
-		assertTrue(ReportManager.getInstance().hasFatalErrors());
-		assertEquals(
-				"Utility should state the short to filter by is not in the cache.",
-				ReportManager.getInstance().getFatalErrors().get(0),
-				"The institution shortname to filter by [swirl] is not in the institution cache.");
-	}
-
-
-	private void confirmResultsAllInstitutions(List<String> allOriginal, List<String> errOriginal) {
-		assertEquals(INST_ALL_NUM_OF_ALL_RESULTS, allOriginal.size());
-		// This is the primary flow that will change when new items / institutions are added to the test institution.
-		// Sort the results in a sandbox to make checking results a bit simplier
-		List<String> all = new ArrayList<>();
-		all.addAll(allOriginal);
-		Collections.sort(all.subList(7, all.size()));
-		List<String> err = new ArrayList<>();
-		err.addAll(errOriginal);
-		Collections.sort(err.subList(7, err.size()));
-		int idx = 7;
-		assertEquals(all.get(idx++), "# Of ALL Attachments,34");
-		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
-		assertEquals(all.get(idx++), "# Of Items affected,5");
-		assertEquals(all.get(idx++), "# Of Items,26");
-		assertEquals(all.get(idx++), "# Of MISSING Attachments,5");
-		idx+=8; //Skip the non-critical rows
-		assertEquals(all.get(idx++), "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0a16eb9d-88af-4951-82bb-40da96516a2f,1,LIVE,file,16fd1eea-86bd-46a4-ae7b-c4b8686bc5dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-		assertEquals(all.get(idx++), "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,f61dc75f-62ca-4cbb-abf2-89bd489cb875,1,LIVE,file,d3e8a4db-f36d-4ff7-a074-728ade56f1d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-		assertEquals(all.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-		assertEquals(all.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d70fa56f-214a-4233-923c-1df83a7c48c1,1,LIVE,file,12abbdce-ffea-4627-aa37-c890cd860a47,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-		assertEquals(all.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,4a0d9c5d-0197-45b8-8c48-7b947ae9c499,1,LIVE,file,f56b2e48-0c68-42e1-8f79-6aa206c0a259,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-		assertEquals(all.get(idx++), "instXc,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,471ba862-8ab9-4b8f-92f5-0f53ad2cad4a,1,LIVE,file,0ddbd2bb-80f5-4ce4-ac26-590cb2e7a03f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,2395ec79-9925-46d6-af54-e6eb21dbfe0a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,39d8186f-6091-4c05-b41c-a907c63f8040,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"áéíóú¿¡üñ.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,416eb301-0ae6-4cb8-925f-02c6cdc61a7f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename with spaces.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,69885964-17f4-47a0-b417-06c1ede16617,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"slashes \\ are fun.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,6ee078cf-5725-438f-a3e0-937130d50277,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,836a7eb4-4897-44cc-9609-e843cbd46bba,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"ascii char \\ test +  . ~ $|=><`#^%&:}{ ]*[\")'(!-;?_,.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,bd2832e9-7d33-4ed6-8b85-15578f629ff5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"semi colons ; test.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,e81439a0-e948-4286-963a-008c5119c2c1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\" الأَبْجَدِيَّة.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,ef97a206-79c8-4235-b078-eaf58025ab29,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0b68c63f-afe7-4f35-b91c-f38609500384,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,19fc300e-290d-49aa-9023-63b6e40b81a9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,4c6f102e-6daf-48f8-aafb-0958b762ee62,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,66995857-0006-467a-91b3-470ac8ea59a0,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7015bfb5-53e0-4c7c-8c7d-a70db97c3441,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,757744c2-0f28-42dd-9884-e3bc548062e9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7643df39-86d6-43aa-af77-3ec3bc6d7f1e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d1a7cd84-295b-4538-815f-d9e35e47bc9e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d5c80e2f-e23e-4dfe-83d7-99877b974d2b,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,dc4a68d0-4209-440f-9d63-de6122162538,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXe,56396b0e-6923-41b9-b936-95475082a213,58d505f8-beef-47d6-a8bb-f52827ccae47,1,LIVE,file,d91f602c-d7f3-4238-a3cc-28df52afb0d9,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-		assertEquals(all.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8b594882-5805-4461-8970-d49c8ce41fb9,1,LIVE,file,fb3c52f6-4d9e-4232-bc1c-64e8d3da36b5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-		assertEquals(all.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8f5254e0-5b0f-4cfe-9af0-9ce2c5d784c5,1,LIVE,file,0578860d-65d7-44bf-8614-08469f268721,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-		assertEquals(all.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d8d002f7-63db-4c0c-bf9e-38d6334af37e,1,LIVE,file,3b24bdd0-f4d7-4bb3-a1cc-383faea4f981,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-		assertEquals(all.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,febe7a26-a556-4b96-bf0b-ff441e525a98,1,LIVE,file,89d0ec7a-0724-48ff-adcf-f29099574f01,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test2.txt\",");
-		assertEquals(all.get(idx++), "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,12f54be4-e536-482d-a7fe-f262ac086b28,1,LIVE,file,66c08dc8-d86f-49eb-84df-20e17e3483d2,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-		assertEquals(all.get(idx++), "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,bfc4e251-f9ba-4c0a-8fea-b37634c5997c,1,LIVE,file,14ec0166-7331-4fdf-8e94-4358aa78728c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "oeqgeneral,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,79b7fa12-7e96-46b1-a8dc-57eeb4dc799a,1,LIVE,file,a8b37c17-a30e-4fc9-9b41-f4fafa8f96c2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-
-		assertEquals(INST_ALL_NUM_OF_ERR_RESULTS, err.size());
-
-		idx = 7;
-		assertEquals(all.get(idx++), "# Of ALL Attachments,34");
-		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
-		assertEquals(all.get(idx++), "# Of Items affected,5");
-		assertEquals(all.get(idx++), "# Of Items,26");
-		assertEquals(all.get(idx++), "# Of MISSING Attachments,5");
-		idx+=8; //Skip the non-critical rows
-		assertEquals(err.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-		assertEquals(err.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(err.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8f5254e0-5b0f-4cfe-9af0-9ce2c5d784c5,1,LIVE,file,0578860d-65d7-44bf-8614-08469f268721,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-		assertEquals(err.get(idx++), "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d8d002f7-63db-4c0c-bf9e-38d6334af37e,1,LIVE,file,3b24bdd0-f4d7-4bb3-a1cc-383faea4f981,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-		assertEquals(err.get(idx++), "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,12f54be4-e536-482d-a7fe-f262ac086b28,1,LIVE,file,66c08dc8-d86f-49eb-84df-20e17e3483d2,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-	}
-
-	private void confirmResultsInstitutionXaAllCollections(List<String> all, List<String> err) {
-		assertEquals(INST_XA_NUM_OF_ALL_RESULTS, all.size());
-
-		int idx = 7;
-		assertEquals(all.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-		assertEquals(all.get(idx++), "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,f61dc75f-62ca-4cbb-abf2-89bd489cb875,1,LIVE,file,d3e8a4db-f36d-4ff7-a074-728ade56f1d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-		assertEquals(all.get(idx++), "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0a16eb9d-88af-4951-82bb-40da96516a2f,1,LIVE,file,16fd1eea-86bd-46a4-ae7b-c4b8686bc5dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-		assertEquals(all.get(idx++), "Stats");
-		assertEquals(all.get(idx++), "# Of Items,2");
-		assertEquals(all.get(idx++), "# Of Items affected,0");
-		assertEquals(all.get(idx++), "# Of ALL Attachments,2");
-		assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
-		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
-
-		assertEquals(INST_XA_NUM_OF_ERR_RESULTS, err.size());
-
-		idx = 7;
-		assertEquals(err.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-		assertEquals(err.get(idx++), "Stats");
-		assertEquals(err.get(idx++), "# Of Items,2");
-		assertEquals(err.get(idx++), "# Of Items affected,0");
-		assertEquals(err.get(idx++), "# Of ALL Attachments,2");
-		assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
-		assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
-	}
-
-	private void confirmResultsInstitutionXbAllCollections(List<String> all, List<String> err) {
-		assertEquals(INST_XB_NUM_OF_ALL_RESULTS, all.size());
-
-		int idx = 7;
-		assertEquals(all.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-		assertEquals(all.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,4a0d9c5d-0197-45b8-8c48-7b947ae9c499,1,LIVE,file,f56b2e48-0c68-42e1-8f79-6aa206c0a259,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-		assertEquals(all.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-		assertEquals(all.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d70fa56f-214a-4233-923c-1df83a7c48c1,1,LIVE,file,12abbdce-ffea-4627-aa37-c890cd860a47,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-		assertEquals(all.get(idx++), "Stats");
-		assertEquals(all.get(idx++), "# Of Items,4");
-		assertEquals(all.get(idx++), "# Of Items affected,2");
-		assertEquals(all.get(idx++), "# Of ALL Attachments,4");
-		assertEquals(all.get(idx++), "# Of MISSING Attachments,2");
-		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
-
-		assertEquals(INST_XB_NUM_OF_ERR_RESULTS, err.size());
-
-		idx = 7;
-		assertEquals(err.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-		assertEquals(err.get(idx++), "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(err.get(idx++), "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-		assertEquals(err.get(idx++), "Stats");
-		assertEquals(err.get(idx++), "# Of Items,4");
-		assertEquals(err.get(idx++), "# Of Items affected,2");
-		assertEquals(err.get(idx++), "# Of ALL Attachments,4");
-		assertEquals(err.get(idx++), "# Of MISSING Attachments,2");
-		assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
-	}
-
-
-	private void confirmResultsInstitutionXcFS2Collection(List<String> all, List<String> err) {
-		assertEquals(INST_XC_COLL_FS2_NUM_ALL_RESULTS, all.size());
-
-		int idx = 7;
-		assertEquals(all.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,6ee078cf-5725-438f-a3e0-937130d50277,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,2395ec79-9925-46d6-af54-e6eb21dbfe0a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,ef97a206-79c8-4235-b078-eaf58025ab29,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,416eb301-0ae6-4cb8-925f-02c6cdc61a7f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename with spaces.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,836a7eb4-4897-44cc-9609-e843cbd46bba,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"ascii char \\ test +  . ~ $|=><`#^%&:}{ ]*[\")'(!-;?_,.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,39d8186f-6091-4c05-b41c-a907c63f8040,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"áéíóú¿¡üñ.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,e81439a0-e948-4286-963a-008c5119c2c1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\" الأَبْجَدِيَّة.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,bd2832e9-7d33-4ed6-8b85-15578f629ff5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"semi colons ; test.log\",");
-		assertEquals(all.get(idx++), "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,69885964-17f4-47a0-b417-06c1ede16617,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"slashes \\ are fun.log\",");
-		assertEquals(all.get(idx++), "Stats");
-		assertEquals(all.get(idx++), "# Of Items,1");
-		assertEquals(all.get(idx++), "# Of Items affected,0");
-		assertEquals(all.get(idx++), "# Of ALL Attachments,9");
-		assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
-		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
-
-		assertEquals(INST_XC_COLL_FS2_NUM_ERR_RESULTS, err.size());
-
-		idx = 7;
-		assertEquals(err.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-		assertEquals(err.get(idx++), "Stats");
-		assertEquals(err.get(idx++), "# Of Items,1");
-		assertEquals(err.get(idx++), "# Of Items affected,0");
-		assertEquals(err.get(idx++), "# Of ALL Attachments,9");
-		assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
-		assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
-	}
-
-
-
-	private void confirmResultsFilterByInstitutionXdAndCollection(List<String> all, List<String> err) {
-		assertEquals(INST_XD_COLL_LR_NUM_ALL_RESULTS, all.size());
-
-		int idx = 7;
-		assertEquals(all.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7015bfb5-53e0-4c7c-8c7d-a70db97c3441,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7643df39-86d6-43aa-af77-3ec3bc6d7f1e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,dc4a68d0-4209-440f-9d63-de6122162538,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d1a7cd84-295b-4538-815f-d9e35e47bc9e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,66995857-0006-467a-91b3-470ac8ea59a0,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,757744c2-0f28-42dd-9884-e3bc548062e9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d5c80e2f-e23e-4dfe-83d7-99877b974d2b,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,19fc300e-290d-49aa-9023-63b6e40b81a9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,4c6f102e-6daf-48f8-aafb-0958b762ee62,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0b68c63f-afe7-4f35-b91c-f38609500384,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
-		assertEquals(all.get(idx++), "Stats");
-		assertEquals(all.get(idx++), "# Of Items,10");
-		assertEquals(all.get(idx++), "# Of Items affected,0");
-		assertEquals(all.get(idx++), "# Of ALL Attachments,10");
-		assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
-		assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
-
-		assertEquals(INST_XD_COLL_LR_NUM_ERR_RESULTS, err.size());
-
-		idx = 7;
-		assertEquals(err.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-		assertEquals(err.get(idx++), "Stats");
-		assertEquals(err.get(idx++), "# Of Items,10");
-		assertEquals(err.get(idx++), "# Of Items affected,0");
-		assertEquals(err.get(idx++), "# Of ALL Attachments,10");
-		assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
-		assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
-	}
-
-
-	private void confirmResultsAllInstitutionsAllItems(List<String> all, List<String> err) {
-		assertEquals(57, all.size());
-
-		int idx = 7;
-		assertEquals(all.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,8428e745-4cdb-4427-8b63-570c81401b2a,1,LIVE,[[Attachment type not set]],[[Attachment UUID not set]],No Att,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,fa6b69a3-4524-4797-93ed-5f9c4cbcb28f,1,LIVE,file,ebf79de1-a336-4886-bec7-3a060666f700,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"plus and spaces+.pdf\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,fa6b69a3-4524-4797-93ed-5f9c4cbcb28f,1,LIVE,file,1d961dd4-2e03-42f2-b028-7c59600c4241,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cceab569-d101-445f-a59d-5cd5500a2b0c,1,LIVE,file,22b26083-6f4f-42fe-abca-befee0eb92a9,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html.zip\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,d896a882-a86a-4f5e-9650-c5f13a6d89d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ) test.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,c4307b91-58c9-4106-bf5b-816ba07e0c3d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ( test.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,53d76799-35d3-4b3e-8634-3b1666b778f5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char \" test.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,3e796f00-731c-4eb2-a483-d93796650099,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char : test.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,be8d38ca-4216-444a-b388-fc8de5d782b6,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char & test.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,9495760a-f8d1-4219-bbe7-0d6518d4bedf,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char control test.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,21d6c550-2ff1-4112-84f6-1f0ca567b6dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test\\this.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,9db63958-5d1b-47b5-aa3d-0d569a598c72,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"|.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,0c85de42-66b7-4446-8e16-7166756214f6,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"*.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,ae61a098-cfc4-452f-8268-695fa0fee94c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"^.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,de9a3fcf-dd07-4e53-99df-ebde4b11c493,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"..txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,a700d38d-bbd4-4b9a-a1fd-4438607bfec8,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"\\.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,3749c0c3-fcf8-427e-98a2-61fd3184f03a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char % [ ] { } ( ) asdf\\ asdf  \\ asdf = 123 \\ test.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,8672147b-3d81-4ca4-84df-41829107e11b,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"fileWithPeriodAfterNonleadingBackslashesRoot\\fileWithPeriodAfterNonleadingBackslashesSubName\\.fileWithPeriodAfterNonleadingBackslashesLeaf\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,bb8f1968-eff2-41b2-9a68-705c4d7f1f2d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ? test.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,e92dfc79-1a30-4682-ab01-b231b70004a1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ' test.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,bd554963-2c55-4da9-9a9f-940ae41b6be1,1,LIVE,file,9d98468c-a040-4dfb-aa94-5500a6ccf467,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,25ecc776-076b-4c9b-b2cf-1f3808007d9d,1,LIVE,file,9465f317-d2a7-48d3-a6e2-27e142b534e8,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,dfe3782d-54b6-4aa2-873d-23c2ef6bf2a8,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,a78040c6-4bd6-48ff-be8a-ce90bcf8f81e,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,726cb654-3f24-4f6b-8c50-02cc5ddbdfeb,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,custom,9827302b-9012-4314-8f1b-053897eadd00,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,395d0c73-dfad-4f01-bb6b-cbcef11ed4db,1,LIVE,file,a4920601-3e3d-4c11-9560-8b9bd9c1baf3,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting2,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,4d410ae3-072a-445c-a2e3-04a0bea8aceb,1,LIVE,file,d95a8e4d-f5b3-4280-a2fc-3bdd68acc26d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,2ed14dab-9103-4073-b8ce-1f134c40e7c5,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,7bf92ca9-84c3-4d9c-8917-d8f806443e10,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,369f980e-b3ae-4b47-9d2f-461a96230828,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cb0461fb-1d0a-4942-ba75-49ed630f0e28,1,LIVE,file,12780b70-31e4-4a93-9e1b-13ab7d09eb78,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cb0461fb-1d0a-4942-ba75-49ed630f0e28,1,LIVE,file,f5f61878-c139-42e1-8ccf-fd985f7c5667,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,attachment,8169c3d4-f6ed-4255-b17c-9f3136f1b85f,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,9964d765-6ead-4fb1-9752-166e7dbf206c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,2d4fe299-4eaf-499d-956e-571c30f13fa0,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"الأَبْجَدِيَّة.pdf\",");
-		assertEquals(all.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,a0954d15-9e55-449a-9f04-a1c065e92440,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.pdf\",");
-		assertEquals(all.get(idx++), "Stats");
-		assertEquals(all.get(idx++), "# Of Items,12");
-		assertEquals(all.get(idx++), "# Of Items affected,2");
-		assertEquals(all.get(idx++), "# Of ALL Attachments,36");
-		assertEquals(all.get(idx++), "# Of MISSING Attachments,2");
-		assertEquals(all.get(idx++), "# Of IGNORED Attachments,5");
-
-		assertEquals(22, err.size());
-
-		idx = 7;
-		assertEquals(err.get(idx++), "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
-		assertEquals(err.get(idx++), "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,25ecc776-076b-4c9b-b2cf-1f3808007d9d,1,LIVE,file,9465f317-d2a7-48d3-a6e2-27e142b534e8,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
-		assertEquals(err.get(idx++), "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,a78040c6-4bd6-48ff-be8a-ce90bcf8f81e,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
-		assertEquals(err.get(idx++), "Stats");
-		assertEquals(err.get(idx++), "# Of Items,12");
-		assertEquals(err.get(idx++), "# Of Items affected,2");
-		assertEquals(err.get(idx++), "# Of ALL Attachments,36");
-		assertEquals(err.get(idx++), "# Of MISSING Attachments,2");
-		assertEquals(err.get(idx++), "# Of IGNORED Attachments,5");
-	}
+  private static final int INST_XA_NUM_OF_ALL_RESULTS = 22;
+  private static final int INST_XA_NUM_OF_ERR_RESULTS = 20;
+  private static final int INST_XB_NUM_OF_ALL_RESULTS = 24;
+  private static final int INST_XB_NUM_OF_ERR_RESULTS = 22;
+  private static final int INST_XC_COLL_FS2_NUM_ALL_RESULTS = 29;
+  private static final int INST_XC_COLL_FS2_NUM_ERR_RESULTS = 20;
+  private static final int INST_XD_COLL_LR_NUM_ALL_RESULTS = 30;
+  private static final int INST_XD_COLL_LR_NUM_ERR_RESULTS = 20;
+  private static final int INST_ALL_NUM_OF_ALL_RESULTS = 54;
+  private static final int INST_ALL_NUM_OF_ERR_RESULTS = 25;
+  private static final int OFFSET_FOR_QUERY_STATEMENT = 3;
+
+  @Test
+  public void testGeneralInstitutionInstXa() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXa");
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsInstitutionXaAllCollections(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_XA_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
+        "# Of queries ran,6");
+  }
+
+  @Test
+  public void testGeneralInstitutionInstXb() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXb");
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsInstitutionXbAllCollections(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_XB_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
+        "# Of queries ran,8");
+  }
+
+  @Test
+  public void testSpecialCharacters() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXc");
+    // Learning Resources
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "1874");
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsInstitutionXcFS2Collection(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_XC_COLL_FS2_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
+        "# Of queries ran,5");
+  }
+
+  @Test
+  public void testFilterByInstitutionAndCollection() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
+    // Learning Resources
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsFilterByInstitutionXdAndCollection(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
+        "# Of queries ran,14");
+  }
+
+  @Test
+  public void testFilterByInstitutionAndCollectionBatchedBy2() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
+    // Learning Resources
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
+    Config.getInstance()
+        .setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
+    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "2");
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsFilterByInstitutionXdAndCollection(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
+        "# Of queries ran,19");
+  }
+
+  @Test
+  public void testFilterByInstitutionAndCollectionBatchedBy9() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
+    // Learning Resources
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
+    Config.getInstance()
+        .setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
+    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "9");
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsFilterByInstitutionXdAndCollection(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
+        "# Of queries ran,16");
+  }
+
+  @Test
+  public void testFilterByInstitutionAndCollectionBatchedBy100() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "instXd");
+    // Learning Resources
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_COLLECTION, "2476");
+    Config.getInstance()
+        .setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
+    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "100");
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsFilterByInstitutionXdAndCollection(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_XD_COLL_LR_NUM_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
+        "# Of queries ran,15");
+  }
+
+  @Test
+  public void testAllInstitutions() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsAllInstitutions(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
+        "# Of queries ran,30");
+  }
+
+  @Test
+  public void testAllInstitutionsConfirmInlineBatchedByDefault() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance()
+        .setConfig(
+            Config.CF_MODE,
+            Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE.name());
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsAllInstitutions(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        "# Of queries ran,32",
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT));
+  }
+
+  @Test
+  public void testAllInstitutionsConfirmInlineBatchedBy1() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance()
+        .setConfig(
+            Config.CF_MODE,
+            Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE.name());
+    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "1");
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsAllInstitutions(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        "# Of queries ran,56",
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT));
+  }
+
+  @Test
+  public void testAllInstitutionsBatchBy1() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance()
+        .setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
+    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "1");
+
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsAllInstitutions(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
+        "# Of queries ran,56");
+  }
+
+  @Test
+  public void testAllInstitutionsBatchBy10() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance()
+        .setConfig(Config.CF_MODE, Config.CheckFilesType.DB_BATCH_ITEMS_PER_ITEM_ATTS.name());
+    Config.getInstance().setConfig(Config.CF_NUM_OF_ITEMS_PER_QUERY, "10");
+
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertTrue(CheckFilesDriver.run());
+    assertTrue(CheckFilesDriver.finalizeRun());
+
+    TestUtils.debugDumpList(ReportManager.getInstance().getAllStatsWriterList());
+    TestUtils.debugDumpList(ReportManager.getInstance().getErrorStatsWriterList());
+    confirmResultsAllInstitutions(
+        ReportManager.getInstance().getAllStatsWriterList(),
+        ReportManager.getInstance().getErrorStatsWriterList());
+    assertEquals(
+        ReportManager.getInstance()
+            .getAllStatsWriterList()
+            .get(INST_ALL_NUM_OF_ALL_RESULTS - OFFSET_FOR_QUERY_STATEMENT),
+        "# Of queries ran,33");
+  }
+
+  @Test
+  public void testItemsInSingleQueryInstitutionFilterBad() {
+    Config.reset();
+    TestUtils.buildCheckFilesGeneralDbProps();
+    Config.getInstance().setConfig(Config.CF_EMAIL_MODE, Config.CheckFilesEmailMode.NONE.name());
+    Config.getInstance().setConfig(Config.CF_FILTER_BY_INSTITUTION, "swirl");
+    Config.getInstance().checkConfigsCheckFiles();
+
+    assertTrue(CheckFilesDriver.setup(true));
+    assertFalse(CheckFilesDriver.run());
+    assertTrue(ReportManager.getInstance().hasFatalErrors());
+    assertEquals(
+        "Utility should state the short to filter by is not in the cache.",
+        ReportManager.getInstance().getFatalErrors().get(0),
+        "The institution shortname to filter by [swirl] is not in the institution cache.");
+  }
+
+  private void confirmResultsAllInstitutions(List<String> allOriginal, List<String> errOriginal) {
+    assertEquals(INST_ALL_NUM_OF_ALL_RESULTS, allOriginal.size());
+    // This is the primary flow that will change when new items / institutions are added to the test
+    // institution.
+    // Sort the results in a sandbox to make checking results a bit simplier
+    List<String> all = new ArrayList<>();
+    all.addAll(allOriginal);
+    Collections.sort(all.subList(7, all.size()));
+    List<String> err = new ArrayList<>();
+    err.addAll(errOriginal);
+    Collections.sort(err.subList(7, err.size()));
+    int idx = 7;
+    assertEquals(all.get(idx++), "# Of ALL Attachments,34");
+    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+    assertEquals(all.get(idx++), "# Of Items affected,5");
+    assertEquals(all.get(idx++), "# Of Items,26");
+    assertEquals(all.get(idx++), "# Of MISSING Attachments,5");
+    idx += 8; // Skip the non-critical rows
+    assertEquals(
+        all.get(idx++),
+        "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0a16eb9d-88af-4951-82bb-40da96516a2f,1,LIVE,file,16fd1eea-86bd-46a4-ae7b-c4b8686bc5dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+    assertEquals(
+        all.get(idx++),
+        "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,f61dc75f-62ca-4cbb-abf2-89bd489cb875,1,LIVE,file,d3e8a4db-f36d-4ff7-a074-728ade56f1d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+    assertEquals(
+        all.get(idx++),
+        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d70fa56f-214a-4233-923c-1df83a7c48c1,1,LIVE,file,12abbdce-ffea-4627-aa37-c890cd860a47,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,4a0d9c5d-0197-45b8-8c48-7b947ae9c499,1,LIVE,file,f56b2e48-0c68-42e1-8f79-6aa206c0a259,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,471ba862-8ab9-4b8f-92f5-0f53ad2cad4a,1,LIVE,file,0ddbd2bb-80f5-4ce4-ac26-590cb2e7a03f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,2395ec79-9925-46d6-af54-e6eb21dbfe0a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,39d8186f-6091-4c05-b41c-a907c63f8040,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"áéíóú¿¡üñ.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,416eb301-0ae6-4cb8-925f-02c6cdc61a7f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename with spaces.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,69885964-17f4-47a0-b417-06c1ede16617,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"slashes \\ are fun.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,6ee078cf-5725-438f-a3e0-937130d50277,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,836a7eb4-4897-44cc-9609-e843cbd46bba,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"ascii char \\ test +  . ~ $|=><`#^%&:}{ ]*[\")'(!-;?_,.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,bd2832e9-7d33-4ed6-8b85-15578f629ff5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"semi colons ; test.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,e81439a0-e948-4286-963a-008c5119c2c1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\" الأَبْجَدِيَّة.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,ef97a206-79c8-4235-b078-eaf58025ab29,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0b68c63f-afe7-4f35-b91c-f38609500384,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,19fc300e-290d-49aa-9023-63b6e40b81a9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,4c6f102e-6daf-48f8-aafb-0958b762ee62,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,66995857-0006-467a-91b3-470ac8ea59a0,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7015bfb5-53e0-4c7c-8c7d-a70db97c3441,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,757744c2-0f28-42dd-9884-e3bc548062e9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7643df39-86d6-43aa-af77-3ec3bc6d7f1e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d1a7cd84-295b-4538-815f-d9e35e47bc9e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d5c80e2f-e23e-4dfe-83d7-99877b974d2b,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,dc4a68d0-4209-440f-9d63-de6122162538,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXe,56396b0e-6923-41b9-b936-95475082a213,58d505f8-beef-47d6-a8bb-f52827ccae47,1,LIVE,file,d91f602c-d7f3-4238-a3cc-28df52afb0d9,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+    assertEquals(
+        all.get(idx++),
+        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8b594882-5805-4461-8970-d49c8ce41fb9,1,LIVE,file,fb3c52f6-4d9e-4232-bc1c-64e8d3da36b5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+    assertEquals(
+        all.get(idx++),
+        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8f5254e0-5b0f-4cfe-9af0-9ce2c5d784c5,1,LIVE,file,0578860d-65d7-44bf-8614-08469f268721,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+    assertEquals(
+        all.get(idx++),
+        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d8d002f7-63db-4c0c-bf9e-38d6334af37e,1,LIVE,file,3b24bdd0-f4d7-4bb3-a1cc-383faea4f981,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,febe7a26-a556-4b96-bf0b-ff441e525a98,1,LIVE,file,89d0ec7a-0724-48ff-adcf-f29099574f01,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test2.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,12f54be4-e536-482d-a7fe-f262ac086b28,1,LIVE,file,66c08dc8-d86f-49eb-84df-20e17e3483d2,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,bfc4e251-f9ba-4c0a-8fea-b37634c5997c,1,LIVE,file,14ec0166-7331-4fdf-8e94-4358aa78728c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "oeqgeneral,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,79b7fa12-7e96-46b1-a8dc-57eeb4dc799a,1,LIVE,file,a8b37c17-a30e-4fc9-9b41-f4fafa8f96c2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+
+    assertEquals(INST_ALL_NUM_OF_ERR_RESULTS, err.size());
+
+    idx = 7;
+    assertEquals(all.get(idx++), "# Of ALL Attachments,34");
+    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+    assertEquals(all.get(idx++), "# Of Items affected,5");
+    assertEquals(all.get(idx++), "# Of Items,26");
+    assertEquals(all.get(idx++), "# Of MISSING Attachments,5");
+    idx += 8; // Skip the non-critical rows
+    assertEquals(
+        err.get(idx++),
+        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+    assertEquals(
+        err.get(idx++),
+        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        err.get(idx++),
+        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,8f5254e0-5b0f-4cfe-9af0-9ce2c5d784c5,1,LIVE,file,0578860d-65d7-44bf-8614-08469f268721,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+    assertEquals(
+        err.get(idx++),
+        "instXe,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d8d002f7-63db-4c0c-bf9e-38d6334af37e,1,LIVE,file,3b24bdd0-f4d7-4bb3-a1cc-383faea4f981,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+    assertEquals(
+        err.get(idx++),
+        "instXe,e03ff4c0-1d4f-4087-bf87-de4b59c6a243,12f54be4-e536-482d-a7fe-f262ac086b28,1,LIVE,file,66c08dc8-d86f-49eb-84df-20e17e3483d2,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+  }
+
+  private void confirmResultsInstitutionXaAllCollections(List<String> all, List<String> err) {
+    assertEquals(INST_XA_NUM_OF_ALL_RESULTS, all.size());
+
+    int idx = 7;
+    assertEquals(
+        all.get(idx++),
+        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+    assertEquals(
+        all.get(idx++),
+        "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,f61dc75f-62ca-4cbb-abf2-89bd489cb875,1,LIVE,file,d3e8a4db-f36d-4ff7-a074-728ade56f1d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "instXa,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0a16eb9d-88af-4951-82bb-40da96516a2f,1,LIVE,file,16fd1eea-86bd-46a4-ae7b-c4b8686bc5dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+    assertEquals(all.get(idx++), "Stats");
+    assertEquals(all.get(idx++), "# Of Items,2");
+    assertEquals(all.get(idx++), "# Of Items affected,0");
+    assertEquals(all.get(idx++), "# Of ALL Attachments,2");
+    assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
+    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+
+    assertEquals(INST_XA_NUM_OF_ERR_RESULTS, err.size());
+
+    idx = 7;
+    assertEquals(
+        err.get(idx++),
+        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+    assertEquals(err.get(idx++), "Stats");
+    assertEquals(err.get(idx++), "# Of Items,2");
+    assertEquals(err.get(idx++), "# Of Items affected,0");
+    assertEquals(err.get(idx++), "# Of ALL Attachments,2");
+    assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
+    assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
+  }
+
+  private void confirmResultsInstitutionXbAllCollections(List<String> all, List<String> err) {
+    assertEquals(INST_XB_NUM_OF_ALL_RESULTS, all.size());
+
+    int idx = 7;
+    assertEquals(
+        all.get(idx++),
+        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+    assertEquals(
+        all.get(idx++),
+        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,4a0d9c5d-0197-45b8-8c48-7b947ae9c499,1,LIVE,file,f56b2e48-0c68-42e1-8f79-6aa206c0a259,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+    assertEquals(
+        all.get(idx++),
+        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d70fa56f-214a-4233-923c-1df83a7c48c1,1,LIVE,file,12abbdce-ffea-4627-aa37-c890cd860a47,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+    assertEquals(all.get(idx++), "Stats");
+    assertEquals(all.get(idx++), "# Of Items,4");
+    assertEquals(all.get(idx++), "# Of Items affected,2");
+    assertEquals(all.get(idx++), "# Of ALL Attachments,4");
+    assertEquals(all.get(idx++), "# Of MISSING Attachments,2");
+    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+
+    assertEquals(INST_XB_NUM_OF_ERR_RESULTS, err.size());
+
+    idx = 7;
+    assertEquals(
+        err.get(idx++),
+        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+    assertEquals(
+        err.get(idx++),
+        "instXb,df727509-77f7-4ce6-a9cb-2c5385565358,3a635ac4-3966-4964-b283-f597d9f11513,1,LIVE,file,e6cd0f56-b3d5-4a5d-9750-9a2119a894ca,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        err.get(idx++),
+        "instXb,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,711de2a7-62e9-41b1-93b9-95cc794e6f7a,1,LIVE,file,fb442db8-71f2-408d-b03b-679c4e2d7220,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+    assertEquals(err.get(idx++), "Stats");
+    assertEquals(err.get(idx++), "# Of Items,4");
+    assertEquals(err.get(idx++), "# Of Items affected,2");
+    assertEquals(err.get(idx++), "# Of ALL Attachments,4");
+    assertEquals(err.get(idx++), "# Of MISSING Attachments,2");
+    assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
+  }
+
+  private void confirmResultsInstitutionXcFS2Collection(List<String> all, List<String> err) {
+    assertEquals(INST_XC_COLL_FS2_NUM_ALL_RESULTS, all.size());
+
+    int idx = 7;
+    assertEquals(
+        all.get(idx++),
+        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,6ee078cf-5725-438f-a3e0-937130d50277,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,2395ec79-9925-46d6-af54-e6eb21dbfe0a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,ef97a206-79c8-4235-b078-eaf58025ab29,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,416eb301-0ae6-4cb8-925f-02c6cdc61a7f,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename with spaces.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,836a7eb4-4897-44cc-9609-e843cbd46bba,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"ascii char \\ test +  . ~ $|=><`#^%&:}{ ]*[\")'(!-;?_,.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,39d8186f-6091-4c05-b41c-a907c63f8040,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"áéíóú¿¡üñ.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,e81439a0-e948-4286-963a-008c5119c2c1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\" الأَبْجَدِيَّة.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,bd2832e9-7d33-4ed6-8b85-15578f629ff5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"semi colons ; test.log\",");
+    assertEquals(
+        all.get(idx++),
+        "instXc,df727509-77f7-4ce6-a9cb-2c5385565358,f232bc42-8871-4f92-b431-f65a94346731,1,LIVE,file,69885964-17f4-47a0-b417-06c1ede16617,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"slashes \\ are fun.log\",");
+    assertEquals(all.get(idx++), "Stats");
+    assertEquals(all.get(idx++), "# Of Items,1");
+    assertEquals(all.get(idx++), "# Of Items affected,0");
+    assertEquals(all.get(idx++), "# Of ALL Attachments,9");
+    assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
+    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+
+    assertEquals(INST_XC_COLL_FS2_NUM_ERR_RESULTS, err.size());
+
+    idx = 7;
+    assertEquals(
+        err.get(idx++),
+        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+    assertEquals(err.get(idx++), "Stats");
+    assertEquals(err.get(idx++), "# Of Items,1");
+    assertEquals(err.get(idx++), "# Of Items affected,0");
+    assertEquals(err.get(idx++), "# Of ALL Attachments,9");
+    assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
+    assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
+  }
+
+  private void confirmResultsFilterByInstitutionXdAndCollection(
+      List<String> all, List<String> err) {
+    assertEquals(INST_XD_COLL_LR_NUM_ALL_RESULTS, all.size());
+
+    int idx = 7;
+    assertEquals(
+        all.get(idx++),
+        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7015bfb5-53e0-4c7c-8c7d-a70db97c3441,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,7643df39-86d6-43aa-af77-3ec3bc6d7f1e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,dc4a68d0-4209-440f-9d63-de6122162538,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d1a7cd84-295b-4538-815f-d9e35e47bc9e,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,66995857-0006-467a-91b3-470ac8ea59a0,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,757744c2-0f28-42dd-9884-e3bc548062e9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,d5c80e2f-e23e-4dfe-83d7-99877b974d2b,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,19fc300e-290d-49aa-9023-63b6e40b81a9,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,4c6f102e-6daf-48f8-aafb-0958b762ee62,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(
+        all.get(idx++),
+        "instXd,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,0b68c63f-afe7-4f35-b91c-f38609500384,1,LIVE,file,a7eafe30-77b3-449e-affc-4a002518409d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.js\",");
+    assertEquals(all.get(idx++), "Stats");
+    assertEquals(all.get(idx++), "# Of Items,10");
+    assertEquals(all.get(idx++), "# Of Items affected,0");
+    assertEquals(all.get(idx++), "# Of ALL Attachments,10");
+    assertEquals(all.get(idx++), "# Of MISSING Attachments,0");
+    assertEquals(all.get(idx++), "# Of IGNORED Attachments,0");
+
+    assertEquals(INST_XD_COLL_LR_NUM_ERR_RESULTS, err.size());
+
+    idx = 7;
+    assertEquals(
+        err.get(idx++),
+        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+    assertEquals(err.get(idx++), "Stats");
+    assertEquals(err.get(idx++), "# Of Items,10");
+    assertEquals(err.get(idx++), "# Of Items affected,0");
+    assertEquals(err.get(idx++), "# Of ALL Attachments,10");
+    assertEquals(err.get(idx++), "# Of MISSING Attachments,0");
+    assertEquals(err.get(idx++), "# Of IGNORED Attachments,0");
+  }
+
+  private void confirmResultsAllInstitutionsAllItems(List<String> all, List<String> err) {
+    assertEquals(57, all.size());
+
+    int idx = 7;
+    assertEquals(
+        all.get(idx++),
+        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,8428e745-4cdb-4427-8b63-570c81401b2a,1,LIVE,[[Attachment type not set]],[[Attachment UUID not set]],No Att,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,fa6b69a3-4524-4797-93ed-5f9c4cbcb28f,1,LIVE,file,ebf79de1-a336-4886-bec7-3a060666f700,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"plus and spaces+.pdf\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,fa6b69a3-4524-4797-93ed-5f9c4cbcb28f,1,LIVE,file,1d961dd4-2e03-42f2-b028-7c59600c4241,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename.log\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cceab569-d101-445f-a59d-5cd5500a2b0c,1,LIVE,file,22b26083-6f4f-42fe-abca-befee0eb92a9,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html.zip\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,d896a882-a86a-4f5e-9650-c5f13a6d89d2,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ) test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,c4307b91-58c9-4106-bf5b-816ba07e0c3d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ( test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,53d76799-35d3-4b3e-8634-3b1666b778f5,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char \" test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,3e796f00-731c-4eb2-a483-d93796650099,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char : test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,be8d38ca-4216-444a-b388-fc8de5d782b6,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char & test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,9495760a-f8d1-4219-bbe7-0d6518d4bedf,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char control test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,21d6c550-2ff1-4112-84f6-1f0ca567b6dd,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test\\this.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,9db63958-5d1b-47b5-aa3d-0d569a598c72,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"|.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,0c85de42-66b7-4446-8e16-7166756214f6,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"*.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,ae61a098-cfc4-452f-8268-695fa0fee94c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"^.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,de9a3fcf-dd07-4e53-99df-ebde4b11c493,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"..txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,a700d38d-bbd4-4b9a-a1fd-4438607bfec8,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"\\.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,3749c0c3-fcf8-427e-98a2-61fd3184f03a,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char % [ ] { } ( ) asdf\\ asdf  \\ asdf = 123 \\ test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,8672147b-3d81-4ca4-84df-41829107e11b,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"fileWithPeriodAfterNonleadingBackslashesRoot\\fileWithPeriodAfterNonleadingBackslashesSubName\\.fileWithPeriodAfterNonleadingBackslashesLeaf\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,bb8f1968-eff2-41b2-9a68-705c4d7f1f2d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ? test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,9da6c4f4-e4f9-431a-93a4-0438a7762747,1,LIVE,file,e92dfc79-1a30-4682-ab01-b231b70004a1,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"char ' test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,6e85ce64-9a11-c5e7-69a4-bd30ec61007f,bd554963-2c55-4da9-9a9f-940ae41b6be1,1,LIVE,file,9d98468c-a040-4dfb-aa94-5500a6ccf467,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.rtf\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,25ecc776-076b-4c9b-b2cf-1f3808007d9d,1,LIVE,file,9465f317-d2a7-48d3-a6e2-27e142b534e8,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,dfe3782d-54b6-4aa2-873d-23c2ef6bf2a8,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,a78040c6-4bd6-48ff-be8a-ce90bcf8f81e,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,726cb654-3f24-4f6b-8c50-02cc5ddbdfeb,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,custom,9827302b-9012-4314-8f1b-053897eadd00,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,395d0c73-dfad-4f01-bb6b-cbcef11ed4db,1,LIVE,file,a4920601-3e3d-4c11-9560-8b9bd9c1baf3,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting2,44ac1c1a-dd0c-462f-b717-53324c0dd6f9,4d410ae3-072a-445c-a2e3-04a0bea8aceb,1,LIVE,file,d95a8e4d-f5b3-4280-a2fc-3bdd68acc26d,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test-filename-with++.log\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,2ed14dab-9103-4073-b8ce-1f134c40e7c5,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,7bf92ca9-84c3-4d9c-8917-d8f806443e10,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,bdb56fa6-00a9-4c2f-89b0-b0de01382b3c,1,LIVE,attachment,369f980e-b3ae-4b47-9d2f-461a96230828,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cb0461fb-1d0a-4942-ba75-49ed630f0e28,1,LIVE,file,12780b70-31e4-4a93-9e1b-13ab7d09eb78,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"syllabus.html\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cb0461fb-1d0a-4942-ba75-49ed630f0e28,1,LIVE,file,f5f61878-c139-42e1-8ccf-fd985f7c5667,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"keyword.txt\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,attachment,8169c3d4-f6ed-4255-b17c-9f3136f1b85f,Ignored,[[Attachment resp code not set]],\"[[Item name not set]]\",\"[[Attachment file path not set]]\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,9964d765-6ead-4fb1-9752-166e7dbf206c,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"oùdéjàn.html\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,2d4fe299-4eaf-499d-956e-571c30f13fa0,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"الأَبْجَدِيَّة.pdf\",");
+    assertEquals(
+        all.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,cbd87c8a-c291-4b9f-861d-6d4478f21685,1,LIVE,file,a0954d15-9e55-449a-9f04-a1c065e92440,Present,[[Attachment resp code not set]],\"[[Item name not set]]\",\"传傳败敗见見.pdf\",");
+    assertEquals(all.get(idx++), "Stats");
+    assertEquals(all.get(idx++), "# Of Items,12");
+    assertEquals(all.get(idx++), "# Of Items affected,2");
+    assertEquals(all.get(idx++), "# Of ALL Attachments,36");
+    assertEquals(all.get(idx++), "# Of MISSING Attachments,2");
+    assertEquals(all.get(idx++), "# Of IGNORED Attachments,5");
+
+    assertEquals(22, err.size());
+
+    idx = 7;
+    assertEquals(
+        err.get(idx++),
+        "Institution Shortname,Collection UUID,Item UUID,Item Version,ItemStatus,Attachment Type,Attachment UUID,Attachment Status,Attachment Response Code,Item Name,Attachment Filepath");
+    assertEquals(
+        err.get(idx++),
+        "checkFilesTesting,97574753-4054-4684-b135-9f8475124a8e,25ecc776-076b-4c9b-b2cf-1f3808007d9d,1,LIVE,file,9465f317-d2a7-48d3-a6e2-27e142b534e8,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
+    assertEquals(
+        err.get(idx++),
+        "checkFilesTesting,5a7b2083-2671-414b-8e5b-c4cd9dfa1f30,ad7a2f0d-7ad5-44cb-9dc6-824f0da38351,1,LIVE,file,a78040c6-4bd6-48ff-be8a-ce90bcf8f81e,Missing,[[Attachment resp code not set]],\"[[Item name not set]]\",\"test.html\",");
+    assertEquals(err.get(idx++), "Stats");
+    assertEquals(err.get(idx++), "# Of Items,12");
+    assertEquals(err.get(idx++), "# Of Items affected,2");
+    assertEquals(err.get(idx++), "# Of ALL Attachments,36");
+    assertEquals(err.get(idx++), "# Of MISSING Attachments,2");
+    assertEquals(err.get(idx++), "# Of IGNORED Attachments,5");
+  }
 }


### PR DESCRIPTION
Enables a oEQt:CF mode of `DB_BATCH_ITEMS_PER_ITEM_ATTS_CONFIRM_INLINE` .  When selected, after the batch of items is cached, CF will cache the item's attachments and check for existence.  

This should reduce false negatives.