### PR TITLE
#32 - ExportItems - enable item exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ export.items.attachment.path.template=@FILENAME
 export.items.multiValueDelim=|
 export.items.oneAttachmentPerLine=true
 # Optional, but if configured, each pair needs to be of the form {uuid}/{version}, where {uuid} is 36 characters long, and {version} is numerical.
-export.items.item.blacklist=uuidX/versionX,uuidY/versionY,...
+export.items.item.exclusions=uuidX/versionX,uuidY/versionY,...
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ export.items.columnFormat=name,uuid,version,attachment_names,metadata/my/values,
 export.items.attachment.path.template=@FILENAME
 export.items.multiValueDelim=|
 export.items.oneAttachmentPerLine=true
+# Optional, but if configured, each pair needs to be of the form {uuid}/{version}, where {uuid} is 36 characters long, and {version} is numerical.
+export.items.item.blacklist=uuidX/versionX,uuidY/versionY,...
 ```
 
 

--- a/src/main/java/org/apereo/openequella/tools/toolbox/Config.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/Config.java
@@ -436,13 +436,13 @@ public class Config {
     checkConfig(EXPORT_ITEMS_ITEM_EXCLUSIONS, true, false);
     if (validConfig && hasConfig(EXPORT_ITEMS_ITEM_EXCLUSIONS)) {
       String[] itemExclusions = getConfigAsStringArray(EXPORT_ITEMS_ITEM_EXCLUSIONS);
-      for (int i = 0; i < itemExclusions.length; i++) {
-        final String[] key = itemExclusions[i].split("/");
+      for(String item : itemExclusions) {
+        final String[] key = item.split("/");
         if ((key.length != 2)) {
           LOGGER.warn(
               "Property {} must be a CSV of item uuid/versions. Found a pair that didn't match [{}].",
                   EXPORT_ITEMS_ITEM_EXCLUSIONS,
-              itemExclusions[i]);
+                  item);
           validConfig = false;
           return;
         }
@@ -451,7 +451,7 @@ public class Config {
           LOGGER.warn(
               "Property {} must be a CSV of item uuid/versions. Found a pair that didn't have the right length of UUID [{}].",
                   EXPORT_ITEMS_ITEM_EXCLUSIONS,
-              itemExclusions[i]);
+                  item);
           validConfig = false;
           return;
         }
@@ -462,7 +462,7 @@ public class Config {
           LOGGER.warn(
               "Property {} must be a CSV of item uuid/versions. Found a pair that didn't have a numeric version [{}].",
                   EXPORT_ITEMS_ITEM_EXCLUSIONS,
-              itemExclusions[i]);
+                  item);
           validConfig = false;
           return;
         }

--- a/src/main/java/org/apereo/openequella/tools/toolbox/Config.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/Config.java
@@ -83,7 +83,7 @@ public class Config {
       "export.items.attachment.path.template";
   public static final String EXPORT_ITEMS_ONE_ATT_PER_LINE = "export.items.oneAttachmentPerLine";
   // Should be a CSV of uuid/version
-  public static final String EXPORT_ITEMS_ITEM_BLACKLIST = "export.items.item.blacklist";
+  public static final String EXPORT_ITEMS_ITEM_EXCLUSIONS = "export.items.item.exclusions";
 
   // Email
   public static final String EMAIL_SERVER = "email.server";
@@ -433,16 +433,16 @@ public class Config {
 
     checkConfig(EXPORT_ITEMS_ATTACHMENT_PATH_TEMPLATE, true, true);
 
-    checkConfig(EXPORT_ITEMS_ITEM_BLACKLIST, true, false);
-    if (validConfig && hasConfig(EXPORT_ITEMS_ITEM_BLACKLIST)) {
-      String[] blacklist = getConfigAsStringArray(EXPORT_ITEMS_ITEM_BLACKLIST);
-      for (int i = 0; i < blacklist.length; i++) {
-        final String[] key = blacklist[i].split("/");
+    checkConfig(EXPORT_ITEMS_ITEM_EXCLUSIONS, true, false);
+    if (validConfig && hasConfig(EXPORT_ITEMS_ITEM_EXCLUSIONS)) {
+      String[] itemExclusions = getConfigAsStringArray(EXPORT_ITEMS_ITEM_EXCLUSIONS);
+      for (int i = 0; i < itemExclusions.length; i++) {
+        final String[] key = itemExclusions[i].split("/");
         if ((key.length != 2)) {
           LOGGER.warn(
               "Property {} must be a CSV of item uuid/versions. Found a pair that didn't match [{}].",
-              EXPORT_ITEMS_ITEM_BLACKLIST,
-              blacklist[i]);
+                  EXPORT_ITEMS_ITEM_EXCLUSIONS,
+              itemExclusions[i]);
           validConfig = false;
           return;
         }
@@ -450,8 +450,8 @@ public class Config {
         if (key[0].length() != 36) {
           LOGGER.warn(
               "Property {} must be a CSV of item uuid/versions. Found a pair that didn't have the right length of UUID [{}].",
-              EXPORT_ITEMS_ITEM_BLACKLIST,
-              blacklist[i]);
+                  EXPORT_ITEMS_ITEM_EXCLUSIONS,
+              itemExclusions[i]);
           validConfig = false;
           return;
         }
@@ -461,8 +461,8 @@ public class Config {
         } catch (NumberFormatException e) {
           LOGGER.warn(
               "Property {} must be a CSV of item uuid/versions. Found a pair that didn't have a numeric version [{}].",
-              EXPORT_ITEMS_ITEM_BLACKLIST,
-              blacklist[i]);
+                  EXPORT_ITEMS_ITEM_EXCLUSIONS,
+              itemExclusions[i]);
           validConfig = false;
           return;
         }

--- a/src/main/java/org/apereo/openequella/tools/toolbox/Config.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/Config.java
@@ -82,6 +82,8 @@ public class Config {
   public static final String EXPORT_ITEMS_ATTACHMENT_PATH_TEMPLATE =
       "export.items.attachment.path.template";
   public static final String EXPORT_ITEMS_ONE_ATT_PER_LINE = "export.items.oneAttachmentPerLine";
+  // Should be a CSV of uuid/version
+  public static final String EXPORT_ITEMS_ITEM_BLACKLIST = "export.items.item.blacklist";
 
   // Email
   public static final String EMAIL_SERVER = "email.server";
@@ -430,6 +432,42 @@ public class Config {
     }
 
     checkConfig(EXPORT_ITEMS_ATTACHMENT_PATH_TEMPLATE, true, true);
+
+    checkConfig(EXPORT_ITEMS_ITEM_BLACKLIST, true, false);
+    if (validConfig && hasConfig(EXPORT_ITEMS_ITEM_BLACKLIST)) {
+      String[] blacklist = getConfigAsStringArray(EXPORT_ITEMS_ITEM_BLACKLIST);
+      for (int i = 0; i < blacklist.length; i++) {
+        final String[] key = blacklist[i].split("/");
+        if ((key.length != 2)) {
+          LOGGER.warn(
+              "Property {} must be a CSV of item uuid/versions. Found a pair that didn't match [{}].",
+              EXPORT_ITEMS_ITEM_BLACKLIST,
+              blacklist[i]);
+          validConfig = false;
+          return;
+        }
+
+        if (key[0].length() != 36) {
+          LOGGER.warn(
+              "Property {} must be a CSV of item uuid/versions. Found a pair that didn't have the right length of UUID [{}].",
+              EXPORT_ITEMS_ITEM_BLACKLIST,
+              blacklist[i]);
+          validConfig = false;
+          return;
+        }
+
+        try {
+          Integer.valueOf(key[1]);
+        } catch (NumberFormatException e) {
+          LOGGER.warn(
+              "Property {} must be a CSV of item uuid/versions. Found a pair that didn't have a numeric version [{}].",
+              EXPORT_ITEMS_ITEM_BLACKLIST,
+              blacklist[i]);
+          validConfig = false;
+          return;
+        }
+      }
+    }
   }
 
   private void checkConfigsFileLister() {

--- a/src/main/java/org/apereo/openequella/tools/toolbox/api/OpenEquellaRestUtils.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/api/OpenEquellaRestUtils.java
@@ -294,12 +294,12 @@ public class OpenEquellaRestUtils {
         cacheStatAvailable,
         resultsLength);
 
-    String[] itemBlacklist = new String[0];
+    String[] itemExclusions = new String[0];
     if ((Config.ToolboxFunction.valueOf(Config.get(Config.TOOLBOX_FUNCTION))
             == Config.ToolboxFunction.ExportItems)
-        && Config.getInstance().hasConfig(Config.EXPORT_ITEMS_ITEM_BLACKLIST)) {
-      itemBlacklist =
-          Config.getInstance().getConfigAsStringArray(Config.EXPORT_ITEMS_ITEM_BLACKLIST);
+        && Config.getInstance().hasConfig(Config.EXPORT_ITEMS_ITEM_EXCLUSIONS)) {
+      itemExclusions =
+          Config.getInstance().getConfigAsStringArray(Config.EXPORT_ITEMS_ITEM_EXCLUSIONS);
     }
 
     if (resultsLength > 0) {
@@ -311,8 +311,8 @@ public class OpenEquellaRestUtils {
         ei.setUuid(confirmAndGatherString(resourceObj, "uuid"));
         ei.setVersion(confirmAndGatherInt(resourceObj, "version"));
         ei.setName(confirmAndGatherString(resourceObj, "name"));
-        if (itemInBlacklist(itemBlacklist, ei)) {
-          LOGGER.info("SKIPPING ITEM due to blacklist match {}", ei.getSignature());
+        if (isItemExcluded(itemExclusions, ei)) {
+          LOGGER.info("SKIPPING ITEM due to exclusion match {}", ei.getSignature());
         } else {
           ei.setDescription(
               resourceObj.has("description") ? resourceObj.getString("description") : "");
@@ -336,10 +336,10 @@ public class OpenEquellaRestUtils {
     return cachedItems;
   }
 
-  private boolean itemInBlacklist(String[] blacklist, ParsedItem parsedItem) {
-    if (blacklist.length > 0) {
-      for (int blacklistIndex = 0; blacklistIndex < blacklist.length; blacklistIndex++) {
-        if (blacklist[blacklistIndex].equals(
+  private boolean isItemExcluded(String[] exclusions, ParsedItem parsedItem) {
+    if (exclusions.length > 0) {
+      for (int exclusionIndex = 0; exclusionIndex < exclusions.length; exclusionIndex++) {
+        if (exclusions[exclusionIndex].equals(
             parsedItem.getUuid() + "/" + parsedItem.getVersion())) {
           return true;
         }

--- a/src/test/java/org/apereo/openequella/tools/toolbox/ExportItemsDriverTest.java
+++ b/src/test/java/org/apereo/openequella/tools/toolbox/ExportItemsDriverTest.java
@@ -19,6 +19,8 @@
 package org.apereo.openequella.tools.toolbox;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Properties;
@@ -137,6 +139,47 @@ public class ExportItemsDriverTest {
     assertEquals("", results.get(5).get(8));
     assertEquals(DATE_CREATED_STR, results.get(5).get(9));
     assertEquals(DATE_MODIFIED_STR, results.get(5).get(10));
+  }
+
+  @Test
+  public void testExportItemsItemBlacklistConfig() throws Exception {
+    Properties props = buildGeneralExportItemsProps();
+    props.put(
+        Config.EXPORT_ITEMS_ATTACHMENT_PATH_TEMPLATE,
+        "/Attachments/@HASH/@UUID/@VERSION/@FILENAME");
+    props.put(Config.EXPORT_ITEMS_ONE_ATT_PER_LINE, "true");
+    props.put(Config.EXPORT_ITEMS_MULTI_VALUE_DELIM, "|");
+    props.put(Config.EXPORT_ITEMS_ITEM_BLACKLIST, "asdf");
+    Config.reset();
+    Config.getInstance().init(props);
+    Config.getInstance().checkConfigs();
+    assertFalse("Config should not be valid", Config.getInstance().isValidConfig());
+
+    props.put(Config.EXPORT_ITEMS_ITEM_BLACKLIST, "qwerty/asdf");
+    Config.reset();
+    Config.getInstance().init(props);
+    Config.getInstance().checkConfigs();
+    assertFalse("Config should not be valid", Config.getInstance().isValidConfig());
+
+    props.put(Config.EXPORT_ITEMS_ITEM_BLACKLIST, "12345678-1234-1234-1234-123456789012/one");
+    Config.reset();
+    Config.getInstance().init(props);
+    Config.getInstance().checkConfigs();
+    assertFalse("Config should not be valid", Config.getInstance().isValidConfig());
+
+    props.put(Config.EXPORT_ITEMS_ITEM_BLACKLIST, "12345678-1234-1234-1234-123456789012/78");
+    Config.reset();
+    Config.getInstance().init(props);
+    Config.getInstance().checkConfigs();
+    assertTrue("Config should be valid", Config.getInstance().isValidConfig());
+
+    props.put(
+        Config.EXPORT_ITEMS_ITEM_BLACKLIST,
+        "12345678-1234-1234-1234-123456789012/78,12345678-1234-1234-1234-123456789056/1,12345678-1234-1234-1234-123456789012/77");
+    Config.reset();
+    Config.getInstance().init(props);
+    Config.getInstance().checkConfigs();
+    assertTrue("Config should be valid", Config.getInstance().isValidConfig());
   }
 
   @Test

--- a/src/test/java/org/apereo/openequella/tools/toolbox/ExportItemsDriverTest.java
+++ b/src/test/java/org/apereo/openequella/tools/toolbox/ExportItemsDriverTest.java
@@ -142,39 +142,39 @@ public class ExportItemsDriverTest {
   }
 
   @Test
-  public void testExportItemsItemBlacklistConfig() throws Exception {
+  public void testExportItemsItemExclusionConfig() throws Exception {
     Properties props = buildGeneralExportItemsProps();
     props.put(
         Config.EXPORT_ITEMS_ATTACHMENT_PATH_TEMPLATE,
         "/Attachments/@HASH/@UUID/@VERSION/@FILENAME");
     props.put(Config.EXPORT_ITEMS_ONE_ATT_PER_LINE, "true");
     props.put(Config.EXPORT_ITEMS_MULTI_VALUE_DELIM, "|");
-    props.put(Config.EXPORT_ITEMS_ITEM_BLACKLIST, "asdf");
+    props.put(Config.EXPORT_ITEMS_ITEM_EXCLUSIONS, "asdf");
     Config.reset();
     Config.getInstance().init(props);
     Config.getInstance().checkConfigs();
     assertFalse("Config should not be valid", Config.getInstance().isValidConfig());
 
-    props.put(Config.EXPORT_ITEMS_ITEM_BLACKLIST, "qwerty/asdf");
+    props.put(Config.EXPORT_ITEMS_ITEM_EXCLUSIONS, "qwerty/asdf");
     Config.reset();
     Config.getInstance().init(props);
     Config.getInstance().checkConfigs();
     assertFalse("Config should not be valid", Config.getInstance().isValidConfig());
 
-    props.put(Config.EXPORT_ITEMS_ITEM_BLACKLIST, "12345678-1234-1234-1234-123456789012/one");
+    props.put(Config.EXPORT_ITEMS_ITEM_EXCLUSIONS, "12345678-1234-1234-1234-123456789012/one");
     Config.reset();
     Config.getInstance().init(props);
     Config.getInstance().checkConfigs();
     assertFalse("Config should not be valid", Config.getInstance().isValidConfig());
 
-    props.put(Config.EXPORT_ITEMS_ITEM_BLACKLIST, "12345678-1234-1234-1234-123456789012/78");
+    props.put(Config.EXPORT_ITEMS_ITEM_EXCLUSIONS, "12345678-1234-1234-1234-123456789012/78");
     Config.reset();
     Config.getInstance().init(props);
     Config.getInstance().checkConfigs();
     assertTrue("Config should be valid", Config.getInstance().isValidConfig());
 
     props.put(
-        Config.EXPORT_ITEMS_ITEM_BLACKLIST,
+        Config.EXPORT_ITEMS_ITEM_EXCLUSIONS,
         "12345678-1234-1234-1234-123456789012/78,12345678-1234-1234-1234-123456789056/1,12345678-1234-1234-1234-123456789012/77");
     Config.reset();
     Config.getInstance().init(props);


### PR DESCRIPTION
Enables `export.items.item.exclude` as a CSV:

```
uuidX/versionX,uuidY/versionY,...
```