### PR TITLE
bugfix: export filenames with tokenized paths; feat:  export collection_name

### DIFF
--- a/src/main/java/org/apereo/openequella/tools/toolbox/api/OpenEquellaRestUtils.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/api/OpenEquellaRestUtils.java
@@ -35,6 +35,7 @@ import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apereo.openequella.tools.toolbox.Config;
+import org.apereo.openequella.tools.toolbox.exportItems.ParsedCollection;
 import org.apereo.openequella.tools.toolbox.exportItems.ParsedItem;
 import org.apereo.openequella.tools.toolbox.utils.FileUtils;
 import org.apereo.openequella.tools.toolbox.utils.MigrationUtils;
@@ -321,6 +322,8 @@ public class OpenEquellaRestUtils {
               Config.DATE_FORMAT_OEQ_API.parse(confirmAndGatherString(resourceObj, "createdDate")));
           ei.setCreatedDateStr(confirmAndGatherString(resourceObj, "createdDate"));
           ei.setModifiedDateStr(confirmAndGatherString(resourceObj, "modifiedDate"));
+          ei.setCollectionUuid(
+              confirmAndGatherString(confirmAndGatherJsonObj(resourceObj, "collection"), "uuid"));
           ei.setJson(resourceObj);
 
           LOGGER.info("CACHED {}", ei.getSignature());
@@ -333,6 +336,67 @@ public class OpenEquellaRestUtils {
     }
 
     return cachedItems;
+  }
+
+  public List<ParsedCollection> gatherCollections() throws Exception {
+    CloseableHttpClient httpclient = HttpClients.createDefault();
+    String url = Config.get(Config.OEQ_URL) + "/api/collection";
+    HttpGet http = new HttpGet(url);
+
+    http.addHeader("X-Authorization", "access_token=" + accessToken);
+    LOGGER.debug("Making the API call: {}", url);
+    HttpResponse response = httpclient.execute(http);
+    HttpEntity entity = response.getEntity();
+
+    int statusCode = response.getStatusLine().getStatusCode();
+
+    String respStr = EntityUtils.toString(entity);
+    LOGGER.trace(statusCode);
+    LOGGER.trace(respStr);
+    if (statusCode != 200) {
+      String msg =
+          String.format(
+              "FAILURE accessing openEQUELLA list collection api [%s]:  %s - %s",
+              url, statusCode, respStr);
+      LOGGER.error(msg);
+      throw new Exception(msg);
+    }
+
+    List<ParsedCollection> cache = new ArrayList<>();
+
+    JSONObject searchResults = new JSONObject(respStr);
+    final int available = confirmAndGatherInt(searchResults, "available");
+    final int length = confirmAndGatherInt(searchResults, "length");
+    if (available != length) {
+      String msg =
+          String.format(
+              "FAILURE to retrieve all collections.  Likely need to implement pagination.  Available = [{}], Length = [{}]",
+              available,
+              length);
+      LOGGER.error(msg);
+      throw new Exception(msg);
+    }
+    JSONArray arr = confirmAndGatherJsonArray(searchResults, "results");
+    int resultsLength = arr.length();
+    LOGGER.info(
+        "Requested collections.  API stats: start=[{}] returned length=[{}], available=[{}], # of results=[{}]",
+        cacheStatStart,
+        cacheStatLength,
+        cacheStatAvailable,
+        resultsLength);
+
+    for (int i = 0; i < arr.length(); i++) {
+      JSONObject resourceObj = arr.getJSONObject(i);
+
+      ParsedCollection pc = new ParsedCollection();
+      pc.setUuid(confirmAndGatherString(resourceObj, "uuid"));
+      pc.setName(confirmAndGatherString(resourceObj, "name"));
+
+      LOGGER.info("CACHED {}", pc.getSignature());
+      cache.add(pc);
+    }
+
+    return cache;
   }
 
   private boolean isItemExcluded(String[] exclusions, ParsedItem parsedItem) {

--- a/src/main/java/org/apereo/openequella/tools/toolbox/api/OpenEquellaRestUtils.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/api/OpenEquellaRestUtils.java
@@ -287,7 +287,7 @@ public class OpenEquellaRestUtils {
     cacheStatAvailable = confirmAndGatherInt(searchResults, "available");
     cacheStatLength = confirmAndGatherInt(searchResults, "length");
     JSONArray itemsArr = confirmAndGatherJsonArray(searchResults, "results");
-    int resultsLength = itemsArr.length();
+    final int resultsLength = itemsArr.length();
     LOGGER.info(
         "Requested batch of resources.  API stats: start=[{}] returned length=[{}], available=[{}], # of results=[{}]",
         cacheStatStart,
@@ -305,7 +305,7 @@ public class OpenEquellaRestUtils {
 
     if (resultsLength > 0) {
       cacheStatStart += resultsLength;
-      for (int i = 0; i < itemsArr.length(); i++) {
+      for (int i = 0; i < resultsLength; i++) {
         JSONObject resourceObj = itemsArr.getJSONObject(i);
 
         ParsedItem ei = new ParsedItem();

--- a/src/main/java/org/apereo/openequella/tools/toolbox/exportItems/ParsedCollection.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/exportItems/ParsedCollection.java
@@ -1,0 +1,27 @@
+package org.apereo.openequella.tools.toolbox.exportItems;
+
+public class ParsedCollection {
+
+  private String uuid;
+  private String name;
+
+  public String getUuid() {
+    return uuid;
+  }
+
+  public void setUuid(String uuid) {
+    this.uuid = uuid;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getSignature() {
+    return "Collection " + name + " (uuid: " + uuid + ")";
+  }
+}

--- a/src/main/java/org/apereo/openequella/tools/toolbox/exportItems/ParsedItem.java
+++ b/src/main/java/org/apereo/openequella/tools/toolbox/exportItems/ParsedItem.java
@@ -41,6 +41,7 @@ public class ParsedItem {
   private String modifiedDateStr;
   private String createdDateStr;
   private String primaryFileType;
+  private String collectionUuid;
 
   public String getKalturaMediaId() {
     return kalturaMediaId;
@@ -152,6 +153,14 @@ public class ParsedItem {
 
   public String getPrimaryFileType() {
     return primaryFileType;
+  }
+
+  public String getCollectionUuid() {
+    return collectionUuid;
+  }
+
+  public void setCollectionUuid(String collectionUuid) {
+    this.collectionUuid = collectionUuid;
   }
 
   public Map<String, List<String>> getParsedMetadata() {

--- a/src/test/java/org/apereo/openequella/tools/toolbox/ExportItemsDriverTest.java
+++ b/src/test/java/org/apereo/openequella/tools/toolbox/ExportItemsDriverTest.java
@@ -105,7 +105,9 @@ public class ExportItemsDriverTest {
     assertEquals("name1", results.get(3).get(0));
     assertEquals("1-2-3-4", results.get(3).get(1));
     assertEquals("1", results.get(3).get(2));
-    assertEquals("file-att-2 with spaces and quotes \" and pipes |.pdf", results.get(3).get(3));
+    assertEquals(
+        "/Attachments/99/1-2-3-4/1/file-att-2 with spaces and quotes \" and pipes |.pdf",
+        results.get(3).get(3));
     assertEquals("nif,ty|This is \" some data!", results.get(3).get(4));
     assertEquals("k1|k2|k3", results.get(3).get(5));
     assertEquals("85645", results.get(3).get(6));
@@ -131,7 +133,7 @@ public class ExportItemsDriverTest {
     assertEquals("name1", results.get(5).get(0));
     assertEquals("1-2-3-4", results.get(5).get(1));
     assertEquals("1", results.get(5).get(2));
-    assertEquals("file-att-1.pdf", results.get(5).get(3));
+    assertEquals("/Attachments/99/1-2-3-4/1/file-att-1.pdf", results.get(5).get(3));
     assertEquals("nif,ty|This is \" some data!", results.get(5).get(4));
     assertEquals("k1|k2|k3", results.get(5).get(5));
     assertEquals("43432", results.get(5).get(6));


### PR DESCRIPTION
Restores the ability for ExportItems to leverage the config:

```
export.items.attachment.path.template=Attachments/@HASH/@UUID/@VERSION/@FILENAME
```

Also enables the config portion:
```
export.items.columnFormat=...,collection_name,...
```